### PR TITLE
Issue 20 - parameters file yaml

### DIFF
--- a/sharc/input/ini2yaml_scraper.py
+++ b/sharc/input/ini2yaml_scraper.py
@@ -1,0 +1,66 @@
+"""
+_summary_
+    Script to be run when you need to convert between old .ini parameters and new .yaml parameters.
+    Usage: `python3 -i input-file.ini -o output-file.yaml`
+    Caveats: currently, it does not parse .ini lists. 
+"""
+
+if __name__ == "__main__":
+
+    import re
+    from argparse import ArgumentParser
+    import os
+    
+    num_spaces_ident = 4
+    
+    parser = ArgumentParser()
+    parser.add_argument("-i", "--input", dest="input_file", help="Input file. Should be .ini. Absolute Path", required=True)
+    parser.add_argument("-o", "--output", dest="output_file", help="Output file. Should be .yaml. Absolute Path", required=True)
+
+    args = parser.parse_args()
+
+    print("Reading from file: ", args.input_file)
+    print("Writing to file: ", args.output_file)
+    
+    input_file_content = open(args.input_file, "r").readlines()
+    
+    # if os.path.exists(args.output_file):
+    #     response = input(f"File {args.output_file} already exists, are you sure that you want to override it? Y/n")
+        # if(response == "n" or response == "N"):
+        #     print("**** Operation Cancelled ****")
+        #     exit(1)
+    with open(args.output_file, 'w') as output_file:
+        current_ident :int = 0 #Identation to be used in yaml file
+        current_section  :str = "" #Section of ini file
+        current_attr_name :str = "" #Attribute name of ini file
+        current_attr_comments : list[str] = []
+        for line in input_file_content:
+            if(line.isspace() or not line):
+                continue
+            line.strip()
+            if(line.startswith("#")):
+                current_attr_comments.append(line)
+                continue
+            elif(line.startswith("[")):
+                #Line is section
+                current_ident = max(current_ident - num_spaces_ident, 0) #go back 1 identation
+                section_name = re.findall(r'\[(.+)\]', line)[0]
+                section_name = section_name.lower()
+                current_section = section_name
+                for comment in current_attr_comments:
+                    output_file.write(' ' * current_ident + comment)
+                current_attr_comments = []
+                output_file.write(' ' * current_ident + f"{current_section}:\n")
+                current_ident += num_spaces_ident
+            else:
+                #line is attribute
+                current_attr_name = re.findall(r"(.+) *=(.+)", line)[0][0]
+                current_attr_value = re.findall(r"(.+) *=(.+)", line)[0][1]
+                if(current_attr_value == 'TRUE' or current_attr_value == 'True'):
+                    current_attr_value = 'true'
+                if(current_attr_value == 'FALSE' or current_attr_value == 'False'):
+                    current_attr_value = 'false'
+                for comment in current_attr_comments:
+                    output_file.write(' ' * current_ident + comment)
+                current_attr_comments = []
+                output_file.write(' ' * current_ident + f"{current_attr_name} :{current_attr_value}\n")

--- a/sharc/input/parameters.yaml
+++ b/sharc/input/parameters.yaml
@@ -1,0 +1,809 @@
+general:
+    ###########################################################################
+    # Number of simulation snapshots
+    num_snapshots  : 100
+    ###########################################################################
+    # IMT link that will be simulated (DOWNLINK or UPLINK)
+    imt_link  : DOWNLINK
+    ###########################################################################
+    # The chosen system for sharing study
+    # EESS_PASSIVE, FSS_SS, FSS_ES, FS, RAS
+    system  : FSS_ES
+    ###########################################################################
+    # Compatibility scenario (co-channel and/or adjacent channel interference)
+    enable_cochannel  : FALSE
+    enable_adjacent_channel  : TRUE
+    ###########################################################################
+    # Seed for random number generator
+    seed  : 101
+    ###########################################################################
+    # if FALSE, then a new output directory is created
+    overwrite_output  : TRUE
+imt:
+    ###########################################################################
+    # Network topology. Possible values are "MACROCELL", "HOTSPOT", "SINGLE_BS"
+    # "INDOOR"
+    topology  : MACROCELL
+    ###########################################################################
+    # Enable wrap around. Available only for "MACROCELL" and "HOTSPOT" topologies
+    wrap_around  : FALSE
+    ###########################################################################
+    # Number of clusters in macro cell topology
+    num_clusters  : 1
+    ###########################################################################
+    # Inter-site distance in macrocell network topology [m]
+    intersite_distance  : 500
+    ###########################################################################
+    # Minimum 2D separation distance from BS to UE [m]
+    minimum_separation_distance_bs_ue  : 0
+    ###########################################################################
+    # Defines if IMT service is the interferer or interfered-with service
+    #   TRUE  : IMT suffers interference
+    #   FALSE : IMT generates interference
+    interfered_with  : FALSE
+    ###########################################################################
+    # IMT center frequency [MHz]
+    frequency  : 24350
+    ###########################################################################
+    # IMT bandwidth [MHz]
+    bandwidth  : 200
+    ###########################################################################
+    # IMT resource block bandwidth [MHz]
+    rb_bandwidth  : 0.180
+    ###########################################################################
+    # IMT spectrum emission mask. Options are:
+    #   "IMT-2020" : for mmWave as described in ITU-R TG 5/1 Contribution 36
+    #   "3GPP E-UTRA" : for E-UTRA bands > 1 GHz as described in 
+    #                   TS 36.104 v11.2.0 (BS) and TS 36.101 v11.2.0 (UE)
+    spectral_mask  : IMT-2020
+    ###########################################################################
+    # level of spurious emissions [dBm/MHz]
+    spurious_emissions  : -13
+    ###########################################################################
+    # Amount of guard band wrt total bandwidth. Setting this parameter to 0.1
+    # means that 10% of the total bandwidth will be used as guard band: 5% in
+    # the lower
+    guard_band_ratio  : 0.1
+    ###########################################################################
+    # The load probability (or activity factor) models the statistical
+    # variation of the network load by defining the number of fully loaded
+    # base stations that are simultaneously transmitting
+    bs_load_probability  : .2
+    ###########################################################################
+    # Conducted power per antenna element [dBm/bandwidth]
+    bs_conducted_power  : 10
+    ###########################################################################
+    # Base station height [m]
+    bs_height  : 6
+    ###########################################################################
+    # Base station noise figure [dB]
+    bs_noise_figure  : 10
+    ###########################################################################
+    # User equipment noise temperature [K]
+    bs_noise_temperature  : 290
+    ###########################################################################
+    # Base station array ohmic loss  [dB]
+    bs_ohmic_loss  : 3
+    ###########################################################################
+    # Uplink attenuation factor used in link-to-system mapping
+    ul_attenuation_factor  : 0.4
+    ###########################################################################
+    # Uplink minimum SINR of the code set [dB]
+    ul_sinr_min  : -10
+    ###########################################################################
+    # Uplink maximum SINR of the code set [dB]
+    ul_sinr_max  : 22
+    ###########################################################################
+    # Number of UEs that are allocated to each cell within handover margin.
+    # Remember that in macrocell network each base station has 3 cells (sectors)
+    ue_k  : 3
+    ###########################################################################
+    # Multiplication factor that is used to ensure that the sufficient number
+    # of UE's will distributed throughout ths system area such that the number
+    # of K users is allocated to each cell. Normally, this values varies
+    # between 2 and 10 according to the user drop method
+    ue_k_m  : 1
+    ###########################################################################
+    # Percentage of indoor UE's [%]
+    ue_indoor_percent  : 5
+    ###########################################################################
+    # Regarding the distribution of active UE's over the cell area, this
+    # parameter states how the UEs will be distributed
+    # Possible values: UNIFORM : UEs will be uniformly distributed within the
+    #                            whole simulation area. Not applicable to
+    #                            hotspots.
+    #                  ANGLE_AND_DISTANCE : UEs will be distributed following
+    #                                   given distributions for angle and
+    #                                   distance. In this case, these must be
+    #                                   defined later.
+    ue_distribution_type  : ANGLE_AND_DISTANCE
+    ###########################################################################
+    # Regarding the distribution of active UE's over the cell area, this
+    # parameter models the distance between UE's and BS.
+    # Possible values: RAYLEIGH, UNIFORM
+    ue_distribution_distance  : RAYLEIGH
+    ###########################################################################
+    # Regarding the distribution of active UE's over the cell area, this
+    # parameter models the azimuth between UE and BS (within ±60° range).
+    # Possible values: NORMAL, UNIFORM
+    ue_distribution_azimuth  : NORMAL
+    ###########################################################################
+    # Power control algorithm
+    # ue_tx_power_control = "ON",power control On
+    # ue_tx_power_control = "OFF",power control Off
+    ue_tx_power_control  : ON
+    ###########################################################################
+    # Power per RB used as target value [dBm]
+    ue_p_o_pusch  : -95
+    ###########################################################################
+    # Alfa is the balancing factor for UEs with bad channel
+    # and UEs with good channel
+    ue_alpha  : 1
+    ###########################################################################
+    # Maximum UE transmit power [dBm]
+    ue_p_cmax  : 22
+    ###########################################################################
+    # UE power dynamic range [dB]
+    # The minimum transmit power of a UE is (ue_p_cmax - ue_dynamic_range)
+    ue_power_dynamic_range  : 63
+    ###########################################################################
+    # UE height [m]
+    ue_height  : 1.5
+    ###########################################################################
+    # User equipment noise figure [dB]
+    ue_noise_figure  : 10
+    ###########################################################################
+    # User equipment feed loss [dB]
+    ue_ohmic_loss  : 3
+    ###########################################################################
+    # User equipment body loss [dB]
+    ue_body_loss  : 4
+    ###########################################################################
+    # Downlink attenuation factor used in link-to-system mapping
+    dl_attenuation_factor  : 0.6
+    ###########################################################################
+    # Downlink minimum SINR of the code set [dB]
+    dl_sinr_min  : -10
+    ###########################################################################
+    # Downlink maximum SINR of the code set [dB]
+    dl_sinr_max  : 30
+    ###########################################################################
+    # Channel parameters
+    # channel model, possible values are "FSPL" (free-space path loss),
+    #                                    "CI" (close-in FS reference distance)
+    #                                    "UMa" (Urban Macro - 3GPP)
+    #                                    "UMi" (Urban Micro - 3GPP)
+    #                                    "TVRO-URBAN"
+    #                                    "TVRO-SUBURBAN"
+    #                                    "ABG" (Alpha-Beta-Gamma)
+    channel_model  : UMi
+    ###########################################################################
+    # Adjustment factor for LoS probability in UMi path loss model.
+    #       Original value: 18 (3GPP)
+    los_adjustment_factor  : 18
+    ###########################################################################
+    # If shadowing should be applied or not
+    shadowing  : TRUE
+    ###########################################################################
+    # System receive noise temperature [K]
+    noise_temperature  : 290
+    BOLTZMANN_CONSTANT  : 1.38064852e-23
+imt_antenna:
+    ###########################################################################
+    # Defines the antenna model to be used in compatibility studies between
+    # IMT and other services in adjacent band
+    # Possible values: SINGLE_ELEMENT, BEAMFORMING
+    adjacent_antenna_model  : SINGLE_ELEMENT
+    ###########################################################################
+    # If normalization of M2101 should be applied for BS
+    bs_normalization  : FALSE
+    ###########################################################################
+    # If normalization of M2101 should be applied for UE
+    ue_normalization  : FALSE
+    ###########################################################################
+    # File to be used in the BS beamforming normalization
+    # Normalization files can be generated with the
+    # antenna/beamforming_normalization/normalize_script.py script
+    bs_normalization_file  : antenna/beamforming_normalization/bs_norm.npz
+    ###########################################################################
+    # File to be used in the UE beamforming normalization
+    # Normalization files can be generated with the 
+    # antenna/beamforming_normalization/normalize_script.py script
+    ue_normalization_file  : antenna/beamforming_normalization/ue_norm.npz
+    ###########################################################################
+    # Radiation pattern of each antenna element
+    # Possible values: "M2101", "F1336", "FIXED"
+    bs_element_pattern  : M2101
+    ue_element_pattern  : M2101
+    ###########################################################################
+    # Minimum array gain for the beamforming antenna [dBi]
+    bs_minimum_array_gain  : -200
+    ue_minimum_array_gain  : -200
+    ###########################################################################
+    # mechanical downtilt [degrees]
+    # NOTE: consider defining it to 90 degrees in case of indoor simulations
+    bs_downtilt  : 6
+    ###########################################################################
+    # BS/UE maximum transmit/receive element gain [dBi]
+    # default: bs_element_max_g = 5, for M.2101
+    #                           = 15, for M.2292
+    # default: ue_element_max_g = 5, for M.2101
+    #                           = -3, for M.2292
+    bs_element_max_g  : 5
+    ue_element_max_g  : 5
+    ###########################################################################
+    # BS/UE horizontal 3dB beamwidth of single element [degrees]
+    bs_element_phi_3db  : 65
+    ue_element_phi_3db  : 90
+    ###########################################################################
+    # BS/UE vertical 3dB beamwidth of single element [degrees]
+    # For F1336: if equal to 0, then beamwidth is calculated automaticaly
+    bs_element_theta_3db  : 65
+    ue_element_theta_3db  : 90
+    ###########################################################################
+    # BS/UE number of rows in antenna array
+    bs_n_rows  : 8
+    ue_n_rows  : 4
+    ###########################################################################
+    # BS/UE number of columns in antenna array
+    bs_n_columns  : 8
+    ue_n_columns  : 4
+    ###########################################################################
+    # BS/UE array horizontal element spacing (d/lambda)
+    bs_element_horiz_spacing  : 0.5
+    ue_element_horiz_spacing  : 0.5
+    ###########################################################################
+    # BS/UE array vertical element spacing (d/lambda)
+    bs_element_vert_spacing  : 0.5
+    ue_element_vert_spacing  : 0.5
+    ###########################################################################
+    # BS/UE front to back ratio of single element [dB]
+    bs_element_am  : 30
+    ue_element_am  : 25
+    ###########################################################################
+    # BS/UE single element vertical sidelobe attenuation [dB]
+    bs_element_sla_v  : 30
+    ue_element_sla_v  : 25
+    ###########################################################################
+    # Multiplication factor k that is used to adjust the single-element pattern.
+    # According to Report ITU-R M.[IMT.AAS], this may give a closer match of the 
+    # side lobes when beamforming is assumed in adjacent channel.
+    #       Original value: 12 (Rec. ITU-R M.2101)
+    bs_multiplication_factor  : 12
+    ue_multiplication_factor  : 12
+hotspot:
+    ###########################################################################
+    # Number of hotspots per macro cell (sector)
+    num_hotspots_per_cell  : 1
+    ###########################################################################
+    # Maximum 2D distance between hotspot and UE [m]
+    # This is the hotspot radius
+    max_dist_hotspot_ue  : 100
+    ###########################################################################
+    # Minimum 2D distance between macro cell base station and hotspot [m]
+    min_dist_bs_hotspot  : 0
+indoor:
+    ###########################################################################
+    # Basic path loss model for indoor topology. Possible values:
+    #       "FSPL" (free-space path loss),
+    #       "INH_OFFICE" (3GPP Indoor Hotspot - Office)
+    basic_path_loss  : INH_OFFICE
+    ###########################################################################
+    # Number of rows of buildings in the simulation scenario
+    n_rows  : 3
+    ###########################################################################
+    # Number of colums of buildings in the simulation scenario
+    n_colums  : 2
+    ###########################################################################
+    # Number of buildings containing IMT stations. Options:
+    # 'ALL': all buildings contain IMT stations.
+    # Number of buildings.
+    num_imt_buildings  : ALL
+    ###########################################################################
+    # Street width (building separation) [m]
+    street_width  : 30
+    ###########################################################################
+    # Intersite distance [m]
+    intersite_distance  : 40
+    ###########################################################################
+    # Number of cells per floor
+    num_cells  : 3
+    ###########################################################################
+    # Number of floors per building
+    num_floors  : 1
+    ###########################################################################
+    # Percentage of indoor UE's [0, 1]
+    ue_indoor_percent  : .95
+    ###########################################################################
+    # Building class: "TRADITIONAL" or "THERMALLY_EFFICIENT"
+    building_class  : TRADITIONAL
+fss_ss:
+    ###########################################################################
+    # satellite center frequency [MHz]
+    frequency  : 43000
+    ###########################################################################
+    # satellite bandwidth [MHz]
+    bandwidth  : 200
+    ###########################################################################
+    # satellite altitude [m] and latitude [deg]
+    altitude  : 35780000
+    lat_deg  : 0
+    ###########################################################################
+    # Elevation angle [deg]
+    elevation  : 270
+    ###########################################################################
+    # Azimuth angle [deg]
+    azimuth  : 0
+    ###########################################################################
+    # Peak transmit power spectral density (clear sky) [dBW/Hz]
+    tx_power_density  : -5
+    ###########################################################################
+    # System receive noise temperature [K]
+    noise_temperature  : 950
+    ###########################################################################
+    # adjacent channel selectivity (dB)
+    adjacent_ch_selectivity  : 0
+    ###########################################################################
+    # Satellite peak receive antenna gain [dBi]
+    antenna_gain  : 46.6
+    ###########################################################################
+    # Antenna pattern of the FSS space station
+    # Possible values: "ITU-R S.672", "ITU-R S.1528", "FSS_SS", "OMNI"
+    antenna_pattern  : FSS_SS
+    # IMT parameters relevant to the satellite system
+    #    altitude of IMT system (in meters)
+    #    latitude of IMT system (in degrees)
+    #    difference between longitudes of IMT and satellite system
+    #      (positive if space-station is to the East of earth-station)
+    imt_altitude  : 0
+    imt_lat_deg  : 0
+    imt_long_diff_deg  : 0
+    season  : SUMMER
+    ###########################################################################
+    # Channel parameters
+    # channel model, possible values are "FSPL" (free-space path loss),
+    #                                    "SatelliteSimple" (FSPL + 4 + clutter loss)
+    #                                    "P619"
+    channel_model  : P619
+    ###########################################################################
+    # The required near-in-side-lobe level (dB) relative to peak gain
+    # according to ITU-R S.672-4
+    antenna_l_s  : -20
+    ###########################################################################
+    # 3 dB beamwidth angle (3 dB below maximum gain) [degrees]
+    antenna_3_dB  : 0.65
+    ###########################################################################
+    # Constants
+    BOLTZMANN_CONSTANT  : 1.38064852e-23
+    EARTH_RADIUS  : 6371000
+fss_es:
+    ###########################################################################
+    # type of FSS-ES location:
+    # FIXED - position must be given
+    # CELL - random within central cell
+    # NETWORK - random within whole network
+    # UNIFORM_DIST - uniform distance from cluster centre,
+    #                between min_dist_to_bs and max_dist_to_bs
+    location  : UNIFORM_DIST
+    ###########################################################################
+    # x-y coordinates [m] (only if FIXED location is chosen)
+    x  : 10000
+    y  : 0
+    ###########################################################################
+    # minimum distance from BSs [m]
+    min_dist_to_bs  : 10
+    ###########################################################################
+    # maximum distance from centre BSs [m] (only if UNIFORM_DIST is chosen)
+    max_dist_to_bs  : 600
+    ###########################################################################
+    # antenna height [m]
+    height  : 6
+    ###########################################################################
+    # Elevation angle [deg], minimum and maximum, values
+    elevation_min  : 48
+    elevation_max  : 80
+    ###########################################################################
+    # Azimuth angle [deg]
+    # either a specific angle or string 'RANDOM'
+    azimuth  : RANDOM
+    ###########################################################################
+    # center frequency [MHz]
+    frequency  : 43000
+    ###########################################################################
+    # bandwidth [MHz]
+    bandwidth  : 6
+    ###########################################################################
+    # System receive noise temperature [K]
+    noise_temperature  : 950
+    ###########################################################################
+    # adjacent channel selectivity (dB)
+    adjacent_ch_selectivity  : 0
+    ###########################################################################
+    # Peak transmit power spectral density (clear sky) [dBW/Hz]
+    tx_power_density  : -68.3
+    ###########################################################################
+    # antenna peak gain [dBi]
+    antenna_gain  : 32
+    ###########################################################################
+    # Antenna pattern of the FSS Earth station
+    # Possible values: "ITU-R S.1855", "ITU-R S.465", "ITU-R S.580", "OMNI",
+    #                  "Modified ITU-R S.465"
+    antenna_pattern  : Modified ITU-R S.465
+    ###########################################################################
+    # Diameter of antenna [m]
+    diameter  : 1.8
+    ###########################################################################
+    # Antenna envelope gain (dBi) - only relevant for "Modified ITU-R S.465" model
+    antenna_envelope_gain  : 0
+    ###########################################################################
+    # Channel parameters
+    # channel model, possible values are "FSPL" (free-space path loss),
+    #                                    "TerrestrialSimple" (FSPL + clutter loss)
+    #                                    "P452"
+    #                                    "TVRO-URBAN"
+    #                                    "TVRO-SUBURBAN"
+    #                                    "HDFSS"
+    channel_model  : P452
+    ###########################################################################
+    # Constants
+    BOLTZMANN_CONSTANT  : 1.38064852e-23
+    EARTH_RADIUS  : 6371000
+    ###########################################################################
+    # P452 parameters
+    ###########################################################################
+    # Total air pressure in hPa
+    atmospheric_pressure  : 935
+    ###########################################################################
+    # Temperature in Kelvin
+    air_temperature  : 300
+    ###########################################################################
+    #Sea-level surface refractivity (use the map)
+    N0  : 352.58
+    ###########################################################################
+    #Average radio-refractive (use the map)
+    delta_N  : 43.127
+    ###########################################################################
+    #percentage p. Float (0 to 100) or RANDOM
+    percentage_p  : 0.2
+    ###########################################################################
+    #Distance over land from the transmit and receive antennas to the coast (km)
+    Dct  : 70
+    ###########################################################################
+    #Distance over land from the transmit and receive antennas to the coast (km)
+    Dcr  : 70
+    ###########################################################################
+    ##Effective height of interfering antenna (m)
+    Hte  : 20
+    ###########################################################################
+    #Effective height of interfered-with antenna (m)
+    Hre  : 3
+    ###########################################################################
+    ##Latitude of transmitter
+    tx_lat  : -23.55028
+    ###########################################################################
+    #Latitude of receiver
+    rx_lat  : -23.17889
+    ###########################################################################
+    #Antenna polarization
+    polarization  : horizontal
+    ###########################################################################
+    #determine whether clutter loss following ITU-R P.2108 is added (TRUE/FALSE)
+    clutter_loss  : TRUE
+    ###########################################################################
+    # HDFSS propagation parameters
+    ###########################################################################
+    # HDFSS position relative to building it is on. Possible values are
+    # ROOFTOP and BUILDINGSIDE
+    es_position  : ROOFTOP
+    ###########################################################################
+    # Enable shadowing loss
+    shadow_enabled  : TRUE
+    ###########################################################################
+    # Enable building entry loss
+    building_loss_enabled  : TRUE
+    ###########################################################################
+    # Enable interference from IMT stations at the same building as the HDFSS
+    same_building_enabled  : FALSE
+    ###########################################################################
+    # Enable diffraction loss
+    diffraction_enabled  : TRUE
+    ###########################################################################
+    # Building entry loss type applied between BSs and HDFSS ES. Options are:
+    # P2109_RANDOM: random probability at P.2109 model, considering elevation
+    # P2109_FIXED: fixed probability at P.2109 model, considering elevation.
+    #              Probability must be specified in bs_building_entry_loss_prob.
+    # FIXED_VALUE: fixed value per BS. Value must be specified in 
+    #              bs_building_entry_loss_value.
+    bs_building_entry_loss_type  : P2109_FIXED
+    ###########################################################################
+    # Probability of building entry loss not exceeded if 
+    # bs_building_entry_loss_type = P2109_FIXED
+    bs_building_entry_loss_prob  : 0.75
+    ###########################################################################
+    # Value in dB of building entry loss if 
+    # bs_building_entry_loss_type = FIXED_VALUE
+    bs_building_entry_loss_value  : 35
+fs:
+    ###########################################################################
+    # x-y coordinates [m]
+    x  : 1000
+    y  : 0
+    ###########################################################################
+    # antenna height [m]
+    height  : 15
+    ###########################################################################
+    # Elevation angle [deg]
+    elevation  : -10
+    ###########################################################################
+    # Azimuth angle [deg]
+    azimuth  : 180
+    ###########################################################################
+    # center frequency [MHz]
+    frequency  : 27250
+    ###########################################################################
+    # bandwidth [MHz]
+    bandwidth  : 112
+    ###########################################################################
+    # System receive noise temperature [K]
+    noise_temperature  : 290
+    ###########################################################################
+    # adjacent channel selectivity (dB)
+    adjacent_ch_selectivity  : 20
+    ###########################################################################
+    # Peak transmit power spectral density (clear sky) [dBW/Hz]
+    tx_power_density  : -68.3
+    ###########################################################################
+    # antenna peak gain [dBi]
+    antenna_gain  : 36.9
+    ###########################################################################
+    # Antenna pattern of the fixed wireless service
+    # Possible values: "ITU-R F.699", "OMNI"
+    antenna_pattern  : ITU-R F.699
+    ###########################################################################
+    # Diameter of antenna [m]
+    diameter  : 0.3
+    ###########################################################################
+    # Channel parameters
+    # channel model, possible values are "FSPL" (free-space path loss),
+    #                                    "TerrestrialSimple" (FSPL + clutter loss)
+    channel_model  : FSPL
+    ###########################################################################
+    # Constants
+    BOLTZMANN_CONSTANT  : 1.38064852e-23
+    EARTH_RADIUS  : 6371000
+haps:
+    ###########################################################################
+    # HAPS center frequency [MHz]
+    frequency  : 27250
+    ###########################################################################
+    # HAPS bandwidth [MHz]
+    bandwidth  : 200
+    ###########################################################################
+    # HAPS altitude [m] and latitude [deg]
+    altitude  : 20000
+    lat_deg  : 0
+    ###########################################################################
+    # Elevation angle [deg]
+    elevation  : 270
+    ###########################################################################
+    # Azimuth angle [deg]
+    azimuth  : 0
+    ###########################################################################
+    # EIRP spectral density [dBW/MHz]
+    eirp_density  : 4.4
+    ###########################################################################
+    # HAPS peak antenna gain [dBi]
+    antenna_gain  : 28.1
+    ###########################################################################
+    # Adjacent channel selectivity [dB]
+    acs  : 30
+    ###########################################################################
+    # Antenna pattern of the HAPS (airbone) station
+    # Possible values: "ITU-R F.1891", "OMNI"
+    antenna_pattern  : ITU-R F.1891
+    # IMT parameters relevant to the HAPS system
+    #    altitude of IMT system (in meters)
+    #    latitude of IMT system (in degrees)
+    #    difference between longitudes of IMT and satellite system
+    #      (positive if space-station is to the East of earth-station)
+    imt_altitude  : 0
+    imt_lat_deg  : 0
+    imt_long_diff_deg  : 0
+    season  : SUMMER
+    ###########################################################################
+    # Channel parameters
+    # channel model, possible values are "FSPL" (free-space path loss),
+    #                                    "SatelliteSimple" (FSPL + 4 + clutter loss)
+    #                                    "P619"
+    channel_model  : P619
+    ###########################################################################
+    # Near side-lobe level (dB) relative to the peak gain required by the system
+    # design, and has a maximum value of −25 dB
+    antenna_l_n  : -25
+    ###########################################################################
+    # Constants
+    BOLTZMANN_CONSTANT  : 1.38064852e-23
+    EARTH_RADIUS  : 6371000
+rns:
+    ###########################################################################
+    # x-y coordinates [m]
+    x  : 660
+    y  : -370
+    ###########################################################################
+    # altitude [m]
+    altitude  : 150
+    ###########################################################################
+    # center frequency [MHz]
+    frequency  : 32000
+    ###########################################################################
+    # bandwidth [MHz]
+    bandwidth  : 60
+    ###########################################################################
+    # System receive noise temperature [K]
+    noise_temperature  : 1154
+    ###########################################################################
+    # Peak transmit power spectral density (clear sky) [dBW/Hz]
+    tx_power_density  : -70.79
+    ###########################################################################
+    # antenna peak gain [dBi]
+    antenna_gain  : 30
+    ###########################################################################
+    # Adjacent channel selectivity [dB]
+    acs  : 30
+    ###########################################################################
+    # Antenna pattern of the fixed wireless service
+    # Possible values: "ITU-R M.1466", "OMNI"
+    antenna_pattern  : ITU-R M.1466
+    ###########################################################################
+    # Channel parameters
+    # channel model, possible values are "FSPL" (free-space path loss),
+    #                                    "SatelliteSimple" (FSPL + 4 dB + clutter loss)
+    #                                    "P619"
+    channel_model  : P619
+    ###########################################################################
+    # Specific parameters for P619
+    season  : SUMMER
+    imt_altitude  : 0
+    imt_lat_deg  : 0
+    ###########################################################################
+    # Constants
+    BOLTZMANN_CONSTANT  : 1.38064852e-23
+    EARTH_RADIUS  : 6371000
+ras:
+    ###########################################################################
+    # x-y coordinates [m]
+    x  : 81000
+    y  : 0
+    ###########################################################################
+    # antenna height [m]
+    height  : 15
+    ###########################################################################
+    # Elevation angle [deg]
+    elevation  : 45
+    ###########################################################################
+    # Azimuth angle [deg]
+    azimuth  : -90
+    ###########################################################################
+    # center frequency [MHz]
+    frequency  : 43000
+    ###########################################################################
+    # bandwidth [MHz]
+    bandwidth  : 1000
+    ###########################################################################
+    # Antenna noise temperature [K]
+    antenna_noise_temperature  : 25
+    ###########################################################################
+    # Receiver noise temperature [K]
+    receiver_noise_temperature  : 65
+    ###########################################################################
+    # adjacent channel selectivity (dB)
+    adjacent_ch_selectivity  : 20
+    ###########################################################################
+    # Antenna efficiency
+    antenna_efficiency  : 1
+    ###########################################################################
+    # Antenna pattern of the FSS Earth station
+    # Possible values: "ITU-R SA.509", "OMNI"
+    antenna_pattern  : ITU-R SA.509
+    ###########################################################################
+    # Antenna gain for "OMNI" pattern
+    antenna_gain  : 0
+    ###########################################################################
+    # Diameter of antenna [m]
+    diameter  : 15
+    ###########################################################################
+    # Constants
+    BOLTZMANN_CONSTANT  : 1.38064852e-23
+    EARTH_RADIUS  : 6371000
+    SPEED_OF_LIGHT  : 299792458
+    ###########################################################################
+    # Channel parameters
+    # channel model, possible values are "FSPL" (free-space path loss),
+    #                                    "TerrestrialSimple" (FSPL + clutter loss)
+    #                                    "P452"
+    channel_model  : P452
+    ###########################################################################
+    # P452 parameters
+    ###########################################################################
+    # Total air pressure in hPa
+    atmospheric_pressure  : 935
+    ###########################################################################
+    # Temperature in Kelvin
+    air_temperature  : 300
+    ###########################################################################
+    #Sea-level surface refractivity (use the map)
+    N0  : 352.58
+    ###########################################################################
+    #Average radio-refractive (use the map)
+    delta_N  : 43.127
+    ###########################################################################
+    #percentage p. Float (0 to 100) or RANDOM
+    percentage_p  : 0.2
+    ###########################################################################
+    #Distance over land from the transmit and receive antennas to the coast (km)
+    Dct  : 70
+    ###########################################################################
+    #Distance over land from the transmit and receive antennas to the coast (km)
+    Dcr  : 70
+    ###########################################################################
+    ##Effective height of interfering antenna (m)
+    Hte  : 20
+    ###########################################################################
+    #Effective height of interfered-with antenna (m)
+    Hre  : 3
+    ###########################################################################
+    ##Latitude of transmitter
+    tx_lat  : -23.55028
+    ###########################################################################
+    #Latitude of receiver
+    rx_lat  : -23.17889
+    ###########################################################################
+    #Antenna polarization
+    polarization  : horizontal
+    ###########################################################################
+    #determine whether clutter loss following ITU-R P.2108 is added (TRUE/FALSE)
+    clutter_loss  : TRUE
+eess_passive:
+    ###########################################################################
+    # sensor center frequency [MHz]
+    frequency  : 23900
+    ###########################################################################
+    # sensor bandwidth [MHz]
+    bandwidth  : 200
+    ###########################################################################
+    # Off-nadir pointing angle [deg]
+    nadir_angle  : 46.6
+    ###########################################################################
+    # sensor altitude [m]
+    altitude  : 828000
+    ###########################################################################
+    # Antenna pattern of the sensor
+    # Possible values: "ITU-R RS.1813"
+    #                  "ITU-R RS.1861 9a"
+    #                  "ITU-R RS.1861 9b"
+    #                  "ITU-R RS.1861 9c"
+    #                  "OMNI"
+    antenna_pattern  : ITU-R RS.1813
+    # Antenna efficiency for pattern described in ITU-R RS.1813 [0-1]
+    antenna_efficiency  : 0.6
+    # Antenna diameter for ITU-R RS.1813 [m]
+    antenna_diameter  : 2.2
+    ###########################################################################
+    # receive antenna gain - applicable for 9a, 9b and OMNI [dBi]
+    antenna_gain  : 52
+    ###########################################################################
+    # Channel parameters
+    # channel model, possible values are "FSPL" (free-space path loss),
+    #                                    "P619"
+    channel_model  : FSPL
+    # Relevant IMT parameters which apply for ITU-R P.619
+    #    altitude of IMT system (in meters)
+    #    latitude of IMT system (in degrees)
+    #    season of the year: "SUMMER", "WINTER"
+    imt_altitude  : 20
+    imt_lat_deg  : -22.9
+    season  : SUMMER
+    ###########################################################################
+    # Constants
+    BOLTZMANN_CONSTANT  : 1.38064852e-23
+    EARTH_RADIUS  : 6371000

--- a/sharc/parameters/parameters.py
+++ b/sharc/parameters/parameters.py
@@ -7,7 +7,7 @@ Created on Wed Aug  9 19:35:52 2017
 
 import sys
 import os
-import configparser
+import yaml
 
 from sharc.parameters.parameters_general import ParametersGeneral
 from sharc.parameters.parameters_imt import ParametersImt
@@ -64,113 +64,113 @@ class Parameters(object):
                 Could not find the configuration file {self.file_name}"
             sys.stderr.write(err_msg)
             sys.exit(1)
+            
+        with open(self.file_name, 'r') as yaml_file:
+            # yaml_config = yaml.safe_load(yaml_file)
 
-        config = configparser.ConfigParser()
-        config.read(self.file_name)
+            #######################################################################
+            # GENERAL
+            #######################################################################
+            self.general.load_parameters_from_file(self.file_name)
 
-        #######################################################################
-        # GENERAL
-        #######################################################################
-        self.general.load_parameters_from_file(self.file_name)
+            #######################################################################
+            # IMT
+            #######################################################################
+            self.imt.load_parameters_from_file(self.file_name)
+            # self.imt.topology                = config.get("IMT", "topology")
+            # self.imt.wrap_around             = config.getboolean("IMT", "wrap_around")
+            # self.imt.num_clusters            = config.getint("IMT", "num_clusters")
+            # self.imt.intersite_distance      = config.getfloat("IMT", "intersite_distance")
+            # self.imt.minimum_separation_distance_bs_ue = config.getfloat("IMT", "minimum_separation_distance_bs_ue")
+            # self.imt.interfered_with         = config.getboolean("IMT", "interfered_with")
+            # self.imt.frequency               = config.getfloat("IMT", "frequency")
+            # self.imt.bandwidth               = config.getfloat("IMT", "bandwidth")
+            # self.imt.rb_bandwidth            = config.getfloat("IMT", "rb_bandwidth")
+            # self.imt.spectral_mask           = config.get("IMT", "spectral_mask")
+            # self.imt.spurious_emissions      = config.getfloat("IMT", "spurious_emissions")
+            # self.imt.guard_band_ratio        = config.getfloat("IMT", "guard_band_ratio")
+            # self.imt.bs_load_probability     = config.getfloat("IMT", "bs_load_probability")
+            # self.imt.bs_conducted_power      = config.getfloat("IMT", "bs_conducted_power")
+            # self.imt.bs_height               = config.getfloat("IMT", "bs_height")
+            # self.imt.bs_noise_figure         = config.getfloat("IMT", "bs_noise_figure")
+            # self.imt.bs_noise_temperature    = config.getfloat("IMT", "bs_noise_temperature")
+            # self.imt.bs_ohmic_loss           = config.getfloat("IMT", "bs_ohmic_loss")
+            # self.imt.ul_attenuation_factor   = config.getfloat("IMT", "ul_attenuation_factor")
+            # self.imt.ul_sinr_min             = config.getfloat("IMT", "ul_sinr_min")
+            # self.imt.ul_sinr_max             = config.getfloat("IMT", "ul_sinr_max")
+            # self.imt.ue_k                    = config.getint("IMT", "ue_k")
+            # self.imt.ue_k_m                  = config.getint("IMT", "ue_k_m")
+            # self.imt.ue_indoor_percent       = config.getfloat("IMT", "ue_indoor_percent")
+            # self.imt.ue_distribution_type    = config.get("IMT", "ue_distribution_type")
+            # self.imt.ue_distribution_distance = config.get("IMT", "ue_distribution_distance")
+            # self.imt.ue_distribution_azimuth = config.get("IMT", "ue_distribution_azimuth")
+            # self.imt.ue_tx_power_control     = config.get("IMT", "ue_tx_power_control")
+            # self.imt.ue_p_o_pusch            = config.getfloat("IMT", "ue_p_o_pusch")
+            # self.imt.ue_alpha                 = config.getfloat("IMT", "ue_alpha")
+            # self.imt.ue_p_cmax               = config.getfloat("IMT", "ue_p_cmax")
+            # self.imt.ue_power_dynamic_range  = config.getfloat("IMT", "ue_power_dynamic_range")
+            # self.imt.ue_height               = config.getfloat("IMT", "ue_height")
+            # self.imt.ue_noise_figure         = config.getfloat("IMT", "ue_noise_figure")
+            # self.imt.ue_ohmic_loss            = config.getfloat("IMT", "ue_ohmic_loss")
+            # self.imt.ue_body_loss            = config.getfloat("IMT", "ue_body_loss")
+            # self.imt.dl_attenuation_factor   = config.getfloat("IMT", "dl_attenuation_factor")
+            # self.imt.dl_sinr_min             = config.getfloat("IMT", "dl_sinr_min")
+            # self.imt.dl_sinr_max             = config.getfloat("IMT", "dl_sinr_max")
+            # self.imt.channel_model           = config.get("IMT", "channel_model")
+            # self.imt.los_adjustment_factor   = config.getfloat("IMT", "los_adjustment_factor")
+            # self.imt.shadowing               = config.getboolean("IMT", "shadowing")
+            # self.imt.noise_temperature       = config.getfloat("IMT", "noise_temperature")
+            # self.imt.BOLTZMANN_CONSTANT      = config.getfloat("IMT", "BOLTZMANN_CONSTANT")
 
-        #######################################################################
-        # IMT
-        #######################################################################
-        self.imt.load_parameters_from_file(self.file_name)
-        # self.imt.topology                = config.get("IMT", "topology")
-        # self.imt.wrap_around             = config.getboolean("IMT", "wrap_around")
-        # self.imt.num_clusters            = config.getint("IMT", "num_clusters")
-        # self.imt.intersite_distance      = config.getfloat("IMT", "intersite_distance")
-        # self.imt.minimum_separation_distance_bs_ue = config.getfloat("IMT", "minimum_separation_distance_bs_ue")
-        # self.imt.interfered_with         = config.getboolean("IMT", "interfered_with")
-        # self.imt.frequency               = config.getfloat("IMT", "frequency")
-        # self.imt.bandwidth               = config.getfloat("IMT", "bandwidth")
-        # self.imt.rb_bandwidth            = config.getfloat("IMT", "rb_bandwidth")
-        # self.imt.spectral_mask           = config.get("IMT", "spectral_mask")
-        # self.imt.spurious_emissions      = config.getfloat("IMT", "spurious_emissions")
-        # self.imt.guard_band_ratio        = config.getfloat("IMT", "guard_band_ratio")
-        # self.imt.bs_load_probability     = config.getfloat("IMT", "bs_load_probability")
-        # self.imt.bs_conducted_power      = config.getfloat("IMT", "bs_conducted_power")
-        # self.imt.bs_height               = config.getfloat("IMT", "bs_height")
-        # self.imt.bs_noise_figure         = config.getfloat("IMT", "bs_noise_figure")
-        # self.imt.bs_noise_temperature    = config.getfloat("IMT", "bs_noise_temperature")
-        # self.imt.bs_ohmic_loss           = config.getfloat("IMT", "bs_ohmic_loss")
-        # self.imt.ul_attenuation_factor   = config.getfloat("IMT", "ul_attenuation_factor")
-        # self.imt.ul_sinr_min             = config.getfloat("IMT", "ul_sinr_min")
-        # self.imt.ul_sinr_max             = config.getfloat("IMT", "ul_sinr_max")
-        # self.imt.ue_k                    = config.getint("IMT", "ue_k")
-        # self.imt.ue_k_m                  = config.getint("IMT", "ue_k_m")
-        # self.imt.ue_indoor_percent       = config.getfloat("IMT", "ue_indoor_percent")
-        # self.imt.ue_distribution_type    = config.get("IMT", "ue_distribution_type")
-        # self.imt.ue_distribution_distance = config.get("IMT", "ue_distribution_distance")
-        # self.imt.ue_distribution_azimuth = config.get("IMT", "ue_distribution_azimuth")
-        # self.imt.ue_tx_power_control     = config.get("IMT", "ue_tx_power_control")
-        # self.imt.ue_p_o_pusch            = config.getfloat("IMT", "ue_p_o_pusch")
-        # self.imt.ue_alpha                 = config.getfloat("IMT", "ue_alpha")
-        # self.imt.ue_p_cmax               = config.getfloat("IMT", "ue_p_cmax")
-        # self.imt.ue_power_dynamic_range  = config.getfloat("IMT", "ue_power_dynamic_range")
-        # self.imt.ue_height               = config.getfloat("IMT", "ue_height")
-        # self.imt.ue_noise_figure         = config.getfloat("IMT", "ue_noise_figure")
-        # self.imt.ue_ohmic_loss            = config.getfloat("IMT", "ue_ohmic_loss")
-        # self.imt.ue_body_loss            = config.getfloat("IMT", "ue_body_loss")
-        # self.imt.dl_attenuation_factor   = config.getfloat("IMT", "dl_attenuation_factor")
-        # self.imt.dl_sinr_min             = config.getfloat("IMT", "dl_sinr_min")
-        # self.imt.dl_sinr_max             = config.getfloat("IMT", "dl_sinr_max")
-        # self.imt.channel_model           = config.get("IMT", "channel_model")
-        # self.imt.los_adjustment_factor   = config.getfloat("IMT", "los_adjustment_factor")
-        # self.imt.shadowing               = config.getboolean("IMT", "shadowing")
-        # self.imt.noise_temperature       = config.getfloat("IMT", "noise_temperature")
-        # self.imt.BOLTZMANN_CONSTANT      = config.getfloat("IMT", "BOLTZMANN_CONSTANT")
+            #######################################################################
+            # IMT ANTENNA
+            #######################################################################
+            self.antenna_imt.load_parameters_from_file(self.file_name)
 
-        #######################################################################
-        # IMT ANTENNA
-        #######################################################################
-        self.antenna_imt.load_parameters_from_file(self.file_name)
+            #######################################################################
+            # HOTSPOT
+            #######################################################################
+            self.hotspot.load_parameters_from_file(self.file_name)
 
-        #######################################################################
-        # HOTSPOT
-        #######################################################################
-        self.hotspot.load_parameters_from_file(self.file_name)
+            #######################################################################
+            # INDOOR
+            #######################################################################
+            self.indoor.load_parameters_from_file(self.file_name)
 
-        #######################################################################
-        # INDOOR
-        #######################################################################
-        self.indoor.load_parameters_from_file(self.file_name)
+            #######################################################################
+            # FSS space station
+            #######################################################################
+            self.fss_ss.load_parameters_from_file(self.file_name)
 
-        #######################################################################
-        # FSS space station
-        #######################################################################
-        self.fss_ss.load_parameters_from_file(self.file_name)
+            #######################################################################
+            # FSS earth station
+            #######################################################################
+            self.fss_es.load_parameters_from_file(self.file_name)
 
-        #######################################################################
-        # FSS earth station
-        #######################################################################
-        self.fss_es.load_parameters_from_file(self.file_name)
+            #######################################################################
+            # Fixed wireless service
+            #######################################################################
+            self.fs.load_parameters_from_file(self.file_name)
 
-        #######################################################################
-        # Fixed wireless service
-        #######################################################################
-        self.fs.load_parameters_from_file(self.file_name)
+            #######################################################################
+            # HAPS (airbone) station
+            #######################################################################
+            self.haps.load_parameters_from_file(self.file_name)
 
-        #######################################################################
-        # HAPS (airbone) station
-        #######################################################################
-        self.haps.load_parameters_from_file(self.file_name)
+            #######################################################################
+            # RNS
+            #######################################################################
+            self.rns.load_parameters_from_file(self.file_name)
 
-        #######################################################################
-        # RNS
-        #######################################################################
-        self.rns.load_parameters_from_file(self.file_name)
+            #######################################################################
+            # RAS station
+            #######################################################################
+            self.ras.load_parameters_from_file(self.file_name)
 
-        #######################################################################
-        # RAS station
-        #######################################################################
-        self.ras.load_parameters_from_file(self.file_name)
-
-        #######################################################################
-        # EESS passive
-        #######################################################################
-        self.eess_passive.load_parameters_from_file(self.file_name)
+            #######################################################################
+            # EESS passive
+            #######################################################################
+            self.eess_passive.load_parameters_from_file(self.file_name)
 
 if __name__ == "__main__":
     from pprint import pprint

--- a/sharc/parameters/parameters_antenna_imt.py
+++ b/sharc/parameters/parameters_antenna_imt.py
@@ -20,7 +20,7 @@ class ParametersAntennaImt(ParametersBase):
     Defines the antenna model and related parameters to be used in compatibility
     studies between IMT and other services in adjacent bands.
     """
-    section_name:str = "IMT_ANTENNA"
+    section_name:str = "imt_antenna"
     # Antenna model for adjacent band studies.
     adjacent_antenna_model:str = "SINGLE_ELEMENT"
 

--- a/sharc/parameters/parameters_base.py
+++ b/sharc/parameters/parameters_base.py
@@ -1,4 +1,4 @@
-import configparser
+import yaml
 from dataclasses import dataclass
 
 @dataclass
@@ -21,40 +21,22 @@ class ParametersBase:
         ValueError
             if a parameter is not valid
         """
-        config = configparser.ConfigParser()
-        config.read(config_file)
+        with open(config_file, 'r') as yaml_file:
+            
+            yaml_config = yaml.safe_load(yaml_file)
 
-        if not self.section_name in config.sections():
-            print(f"ParameterBase: section {self.section_name} not in parameter file.\
-                  Only default parameters where loaded.")
-            return
+            if not self.section_name in yaml_config.keys():
+                print(f"ParameterBase: section {self.section_name} not in parameter file.\
+                    Only default parameters where loaded.")
+                return
 
-        # Load all the parameters from the configuration file
-        attr_list = [a for a in dir(self) if not a.startswith('__') and not
-                     callable(getattr(self, a)) and a != "section_name"]
+            # Load all the parameters from the configuration file
+            attr_list = [a for a in dir(self) if not a.startswith('__') and not
+                        callable(getattr(self, a)) and a != "section_name"]
 
-        for attr_name in attr_list:
-            try:
-                attr_val = getattr(self, attr_name)
-                if isinstance(attr_val, str):
-                    setattr(self, attr_name, config.get(self.section_name, attr_name))
-                elif isinstance(attr_val, bool):
-                    setattr(self, attr_name, config.getboolean(self.section_name, attr_name))
-                elif isinstance(attr_val, float):
-                    setattr(self, attr_name, config.getfloat(self.section_name, attr_name))
-                elif isinstance(attr_val, int):
-                    setattr(self, attr_name, config.getint(self.section_name, attr_name))
-                elif isinstance(attr_val, tuple):
-                    # Check if the string defines a list of floats
-                    try:
-                        param_val = config.get(self.section_name, attr_name)
-                        tmp_val = list(map(float, param_val.split(",")))
-                        setattr(self, attr_name, tuple(tmp_val))
-                    except ValueError:
-                        # its a regular string. Let the specific class implementation
-                        # do the sanity check
-                        print(f"ParametersBase: could not convert string to tuple \"{self.section_name}.{attr_name}\"")
-                        exit()
-
-            except configparser.NoOptionError:
-                print(f"ParametersBase: NOTICE! Configuration parameter \"{self.section_name}.{attr_name}\" is not set in configuration file. Using default value {attr_val}")
+            for attr_name in attr_list:
+                try:
+                    attr_val = getattr(self, attr_name)
+                    setattr(self, attr_name, yaml_config[self.section_name][attr_name])
+                except:
+                    print(f"ParametersBase: NOTICE! Configuration parameter \"{self.section_name}.{attr_name}\" is not set in configuration file. Using default value {attr_val}")

--- a/sharc/parameters/parameters_eess_passive.py
+++ b/sharc/parameters/parameters_eess_passive.py
@@ -7,7 +7,7 @@ class ParametersEessPassive(ParametersBase):
     Defines parameters for passive Earth Exploration Satellite Service (EESS) sensors
     and their interaction with other services based on ITU recommendations.
     """
-    section_name: str = "EESS_PASSIVE"
+    section_name: str = "eess_passive"
     
     # Sensor center frequency [MHz]
     frequency:float = 23900.0  # Center frequency of the sensor in MHz

--- a/sharc/parameters/parameters_fs.py
+++ b/sharc/parameters/parameters_fs.py
@@ -7,7 +7,7 @@ class ParametersFs(ParametersBase):
     Parameters definitions for fixed wireless service systems.
     """
 
-    section_name: str = "FS"
+    section_name: str = "fs"
 
     # x-y coordinates [meters]
     x:float = 1000.0

--- a/sharc/parameters/parameters_fss_es.py
+++ b/sharc/parameters/parameters_fss_es.py
@@ -10,7 +10,7 @@ class ParametersFssEs(ParametersBase):
     """Dataclass containing the Fixed Satellite Services - Earth Station
     parameters for the simulator
     """
-    section_name: str = "FSS_ES"
+    section_name: str = "fss_es"
     
     # type of FSS-ES location:
     # FIXED - position must be given
@@ -155,9 +155,8 @@ class ParametersFssEs(ParametersBase):
                                 Invalid value for parameter azimuth - {self.azimuth}.
                                 Allowed values are \"RANDOM\" or a angle in degrees.""")
 
-        if is_float(self.percentage_p):
-            self.percentage_p = float(self.percentage_p)
-        elif self.percentage_p.upper() != "RANDOM":
+        
+        if isinstance(self.percentage_p, str) and self.percentage_p.upper() != "RANDOM":
             raise ValueError(f"""ParametersFssEs:
                             Invalid value for parameter azimuth - {self.percentage_p}.
                             Allowed values are \"RANDOM\" or a percentage ]0,1]""")

--- a/sharc/parameters/parameters_fss_ss.py
+++ b/sharc/parameters/parameters_fss_ss.py
@@ -8,7 +8,7 @@ class ParametersFssSs(ParametersBase):
     """Dataclass containing the Fixed Satellite Services - Space Station
     parameters for the simulator
     """
-    section_name: str = "FSS_SS"
+    section_name: str = "fss_ss"
     # satellite center frequency [MHz]
     frequency: float = 43000.0
     # satellite bandwidth [MHz]

--- a/sharc/parameters/parameters_general.py
+++ b/sharc/parameters/parameters_general.py
@@ -9,7 +9,7 @@ from sharc.parameters.parameters_base import ParametersBase
 class ParametersGeneral(ParametersBase):
     """Dataclass containing the general parameters for the simulator
     """
-    section_name: str = "GENERAL"
+    section_name: str = "general"
     num_snapshots: int = 10000
     imt_link: str = "DOWNLINK"
     system: str = "RAS"

--- a/sharc/parameters/parameters_haps.py
+++ b/sharc/parameters/parameters_haps.py
@@ -8,7 +8,7 @@ from sharc.parameters.parameters_base import ParametersBase
 class ParametersHaps(ParametersBase):
     """Dataclass containing the IMT system parameters
     """
-    section_name: str = "HAPS"
+    section_name: str = "haps"
     # HAPS center frequency [MHz]
     frequency: float = 27250.0
     # HAPS bandwidth [MHz]

--- a/sharc/parameters/parameters_hotspot.py
+++ b/sharc/parameters/parameters_hotspot.py
@@ -6,7 +6,7 @@ class ParametersHotspot(ParametersBase):
     """
     Parameters definitions for Hotspot systems.
     """
-    section_name: str = "HOTSPOT"
+    section_name: str = "hotspot"
     # Number of hotspots per macro cell (sector).
     num_hotspots_per_cell:int = 1
 

--- a/sharc/parameters/parameters_imt.py
+++ b/sharc/parameters/parameters_imt.py
@@ -10,7 +10,7 @@ from sharc.parameters.parameters_base import ParametersBase
 class ParametersImt(ParametersBase):
     """Dataclass containing the IMT system parameters
     """
-    section_name: str = "IMT"
+    section_name: str = "imt"
     topology: str = "MACROCELL"
     wrap_around: bool = False
     num_clusters: int = 1

--- a/sharc/parameters/parameters_indoor.py
+++ b/sharc/parameters/parameters_indoor.py
@@ -10,7 +10,7 @@ class ParametersIndoor(ParametersBase):
     """
     Simulation parameters for indoor network topology.
     """
-    section_name: str = "INDOOR"
+    section_name: str = "indoor"
     
     # Basic path loss model for indoor topology.
     # Possible values: "FSPL" (free-space path loss), "INH_OFFICE" (3GPP Indoor Hotspot - Office)

--- a/sharc/parameters/parameters_ras.py
+++ b/sharc/parameters/parameters_ras.py
@@ -10,7 +10,7 @@ class ParametersRas(ParametersBase):
     """
     Simulation parameters for Radio Astronomy Service
     """
-    section_name: str = "RAS"
+    section_name: str = "ras"
     # x-y coordinates [m]
     x: float = 81000.0
     y: float = 0.0
@@ -99,9 +99,7 @@ class ParametersRas(ParametersBase):
             raise ValueError(f"ParametersRas: \
                              Invalid value for parameter polarization - {self.polarization}. \
                              Allowed values are: \"horizontal\", \"vertical\"")
-        if is_float(self.percentage_p):
-            self.percentage_p = float(self.percentage_p)
-        elif self.percentage_p.upper() != "RANDOM":
+        if isinstance(self.percentage_p, str) and self.percentage_p.upper() != "RANDOM":
             raise ValueError(f"""ParametersRas:
                             Invalid value for parameter percentage_p - {self.percentage_p}.
                             Allowed values are \"RANDOM\" or a percentage ]0,1]""")

--- a/sharc/parameters/parameters_rns.py
+++ b/sharc/parameters/parameters_rns.py
@@ -9,7 +9,7 @@ class ParametersRns(ParametersBase):
     """
     Simulation parameters for radionavigation service
     """
-    section_name: str = "RNS"
+    section_name: str = "rns"
     # x-y coordinates [m]
     x: float = 660.0
     y: float = -370.0

--- a/sharc/support/footprint.py
+++ b/sharc/support/footprint.py
@@ -37,13 +37,13 @@ class Footprint(object):
             self.sat_height = kwargs['sat_height']
             self.sigma = EARTH_RADIUS / (EARTH_RADIUS + self.sat_height)
             self.bore_lat_deg = 0.0
-            self.bore_subsat_long_deg = self.calc_beta(self.elevation_deg, self.sat_height)
+            self.bore_subsat_long_deg = self.calc_beta(self.elevation_deg)
         elif 'elevation_deg' in kwargs.keys() and 'sat_height' not in kwargs.keys():
             self.elevation_deg = kwargs['elevation_deg']
             self.bore_lat_deg = 0.0
             self.sat_height = 35786000
             self.sigma = EARTH_RADIUS / (EARTH_RADIUS + self.sat_height)
-            self.bore_subsat_long_deg = self.calc_beta(self.elevation_deg, self.sat_height)
+            self.bore_subsat_long_deg = self.calc_beta(self.elevation_deg)
         else:
             self.sat_height = 35786000
             self.sigma = EARTH_RADIUS / (EARTH_RADIUS + self.sat_height)
@@ -117,7 +117,7 @@ class Footprint(object):
         """
         self.elevation_deg = elev
         self.bore_lat_deg = 0.0
-        self.bore_subsat_long_deg = self.calc_beta(self.elevation_deg, self.sat_height)
+        self.bore_subsat_long_deg = self.calc_beta(self.elevation_deg)
         
         # Convert to radians
         self.elevation_rad = deg2rad(self.elevation_deg)

--- a/sharc/support/footprint.py
+++ b/sharc/support/footprint.py
@@ -35,14 +35,18 @@ class Footprint(object):
         if 'elevation_deg' in kwargs.keys() and 'sat_height' in kwargs.keys():
             self.elevation_deg = kwargs['elevation_deg']
             self.sat_height = kwargs['sat_height']
+            self.sigma = EARTH_RADIUS / (EARTH_RADIUS + self.sat_height)
             self.bore_lat_deg = 0.0
             self.bore_subsat_long_deg = self.calc_beta(self.elevation_deg, self.sat_height)
         elif 'elevation_deg' in kwargs.keys() and 'sat_height' not in kwargs.keys():
             self.elevation_deg = kwargs['elevation_deg']
             self.bore_lat_deg = 0.0
             self.sat_height = 35786000
+            self.sigma = EARTH_RADIUS / (EARTH_RADIUS + self.sat_height)
             self.bore_subsat_long_deg = self.calc_beta(self.elevation_deg, self.sat_height)
         else:
+            self.sat_height = 35786000
+            self.sigma = EARTH_RADIUS / (EARTH_RADIUS + self.sat_height)
             self.bore_lat_deg = 0.0
             self.bore_subsat_long_deg = 0.0
             if 'bore_lat_deg' in kwargs.keys():
@@ -51,10 +55,11 @@ class Footprint(object):
                 self.bore_subsat_long_deg = kwargs['bore_subsat_long_deg']
             self.elevation_deg = \
                 self.calc_elevation(self.bore_lat_deg,self.bore_subsat_long_deg)
-            self.sat_height = 35786000
+            
         
         self.beam_width_deg = beam_deg
-        
+        # sigma is the relation bewtween earth radius and satellite height
+        # print(self.sigma) 
         # Convert to radians
         self.elevation_rad = deg2rad(self.elevation_deg)
         self.bore_lat_rad = deg2rad(self.bore_lat_deg)
@@ -64,29 +69,28 @@ class Footprint(object):
         # Calculate tilt
         self.beta = arccos(cos(self.bore_lat_rad)*\
                            cos(self.bore_subsat_long_rad))
-        self.bore_tilt = arctan2(sin(self.beta),(6.6235 - cos(self.beta)))
+        self.bore_tilt = arctan2(sin(self.beta),((1/self.sigma) - cos(self.beta)))
         
         # Maximum tilt and latitute coverage
         self.max_gamma_rad = deg2rad(8.6833)
         self.max_beta_rad = deg2rad(81.3164)
         
-    def calc_beta(self,elev_deg: float, sat_height : int):
+    def calc_beta(self,elev_deg: float):
         """
         Calculates elevation angle based on given elevation. Beta is the 
         subpoint to earth station great-circle distance
         
         Input:
             elev_deg (float): elevation in degrees
-            sat_height (int): satellite height in meters
             
         Output:
             beta (float): beta angle in degrees  
         """
         elev_rad = deg2rad(elev_deg)
-        beta = 90 - elev_deg - rad2deg(arcsin(cos(elev_rad)/((EARTH_RADIUS + sat_height)/EARTH_RADIUS)))
+        beta = 90 - elev_deg - rad2deg(arcsin(cos(elev_rad)*self.sigma))
         return beta
     
-    def calc_elevation(self,lat_deg: float, long_deg: float, sat_height: int):
+    def calc_elevation(self,lat_deg: float, long_deg: float):
         """
         Calculates elevation for given latitude of boresight point and 
         longitude of boresight with respect to sub-satellite point.
@@ -96,7 +100,6 @@ class Footprint(object):
             long_deg (float): longitude of boresight with respect
                 to sub-satellite point, taken positive when to the west of the
                 sub-satellite point, in degrees
-            sat_height (int): satellite height in meters
         
         Output:
             elev (float): elevation in degrees
@@ -104,7 +107,7 @@ class Footprint(object):
         lat_rad = deg2rad(lat_deg)
         long_rad = deg2rad(long_deg)
         beta = arccos(cos(lat_rad)*cos(long_rad))
-        elev = arctan2((cos(beta) - 0.1510),sin(beta))
+        elev = arctan2((cos(beta) - self.sigma),sin(beta))
         
         return rad2deg(elev)
     
@@ -124,7 +127,7 @@ class Footprint(object):
         # Calculate tilt
         self.beta = arccos(cos(self.bore_lat_rad)*\
                            cos(self.bore_subsat_long_rad))
-        self.bore_tilt = arctan2(sin(self.beta),(6.6235 - cos(self.beta)))
+        self.bore_tilt = arctan2(sin(self.beta),(1/self.sigma - cos(self.beta)))
         
     def calc_footprint(self, n: int):
         """
@@ -151,7 +154,7 @@ class Footprint(object):
         eps_n = arctan2(sin(self.bore_subsat_long_rad),tan(self.bore_lat_rad)) + \
                 phi_n
                 
-        beta_n = arcsin(6.6235*sin(gamma_n)) - gamma_n
+        beta_n = arcsin((1/self.sigma)*sin(gamma_n)) - gamma_n
         beta_n[where(gamma_n >  self.max_gamma_rad)] = self.max_beta_rad
         
         pt_lat  = arcsin(sin(beta_n)*cos(eps_n))
@@ -168,6 +171,9 @@ class Footprint(object):
         Output:
             a (float): footprint area in km^2
         """
+        
+        #Sob condições ideais, com 90 graus de eleveção, a conta é simplificada como : A = pi * (sat_height * tan(beam_deg * (pi/180))) ^ 2
+        
         long, lat = self.calc_footprint(n)
         
         long_lat = vstack((long, lat)).T
@@ -184,15 +190,13 @@ class Footprint(object):
         return pi/2 - arctan(x)
         
 if __name__ == '__main__':
-    # Earth  [km]
-    R = 6371
     
     #Create 20km footprints
-    footprint_20km_10deg = Footprint(0.325, elevation_deg=10, sat_height=20000)
-    footprint_20km_20deg = Footprint(0.325, elevation_deg=20, sat_height=20000)
-    footprint_20km_30deg = Footprint(0.325, elevation_deg=30, sat_height=20000)
-    footprint_20km_45deg = Footprint(0.325, elevation_deg=45, sat_height=20000)
-    footprint_20km_90deg = Footprint(0.325, elevation_deg=90, sat_height=20000)
+    footprint_20km_10deg = Footprint(5, elevation_deg=10, sat_height=20000)
+    footprint_20km_20deg = Footprint(5, elevation_deg=20, sat_height=20000)
+    footprint_20km_30deg = Footprint(5, elevation_deg=30, sat_height=20000)
+    footprint_20km_45deg = Footprint(5, elevation_deg=45, sat_height=20000)
+    footprint_20km_90deg = Footprint(5, elevation_deg=90, sat_height=20000)
     
     plt.figure(figsize=(15,2))
     n = 100
@@ -207,20 +211,22 @@ if __name__ == '__main__':
     lng,lat = footprint_20km_10deg.calc_footprint(n)
     plt.plot(lng, lat, 'y', label= f'$10^o$')
     
+    plt.title("Footprints at 20km")
     plt.legend(loc='upper right')
     plt.xlabel('Longitude [deg]')
     plt.ylabel('Latitude [deg]')
-    plt.xlim([-5, 6])
+    # plt.xlim([-5, 6])
     plt.grid()
     plt.show()
     
     
     #Create 500km footprints
-    footprint_500km_10deg = Footprint(0.325, elevation_deg=10, sat_height=500000)
-    footprint_500km_20deg = Footprint(0.325, elevation_deg=20, sat_height=500000)
-    footprint_500km_30deg = Footprint(0.325, elevation_deg=30, sat_height=500000)
-    footprint_500km_45deg = Footprint(0.325, elevation_deg=45, sat_height=500000)
-    footprint_500km_90deg = Footprint(0.325, elevation_deg=90, sat_height=500000)
+    footprint_500km_10deg = Footprint(5, elevation_deg=10, sat_height=500000)
+    footprint_500km_20deg = Footprint(5, elevation_deg=20, sat_height=500000)
+    footprint_500km_30deg = Footprint(5, elevation_deg=30, sat_height=500000)
+    footprint_500km_45deg = Footprint(5, elevation_deg=45, sat_height=500000)
+    footprint_500km_90deg = Footprint(5, elevation_deg=90, sat_height=500000)
+    print("Sat at 500km elevation 90 deg: area = {}".format(footprint_500km_90deg.calc_area(n)))
     
     plt.figure(figsize=(15,2))
     n = 100
@@ -235,10 +241,11 @@ if __name__ == '__main__':
     lng,lat = footprint_500km_10deg.calc_footprint(n)
     plt.plot(lng, lat, 'y', label= f'$10^o$')
     
+    plt.title("Footprints at 500km")
     plt.legend(loc='upper right')
     plt.xlabel('Longitude [deg]')
     plt.ylabel('Latitude [deg]')
-    plt.xlim([-5, 20])
+    # plt.xlim([-5, 20])
     plt.grid()
     plt.show()
     
@@ -263,10 +270,12 @@ if __name__ == '__main__':
     plt.plot(long,lat,'g',label='$20^o$')
     long, lat = fprint05.calc_footprint(n)
     plt.plot(long,lat,'y',label='$5^o$')
+    
+    plt.title("Footprints at 35786km (GEO)")
     plt.legend(loc='upper right')
     plt.xlabel('Longitude [deg]')
     plt.ylabel('Latitude [deg]')
-    plt.xlim([-5, 90])
+    # plt.xlim([-5, 90])
     plt.grid()
     plt.show()
     
@@ -296,9 +305,9 @@ if __name__ == '__main__':
     area_500km = zeros_like(elevation)
     area_35786km = zeros_like(elevation)
     
-    fprint_20km = Footprint(0.320,elevation_deg=0, sat_height=20000)
-    fprint_500km = Footprint(0.320,elevation_deg=0, sat_height=500000)
-    fprint_35786km = Footprint(0.320,elevation_deg=0, sat_height=35786000)
+    fprint_20km = Footprint(5,elevation_deg=0, sat_height=20000)
+    fprint_500km = Footprint(5,elevation_deg=0, sat_height=500000)
+    fprint_35786km = Footprint(0.325,elevation_deg=0, sat_height=35786000)
     
     for k in range(len(elevation)):
         fprint_20km.set_elevation(elevation[k])
@@ -310,7 +319,7 @@ if __name__ == '__main__':
         
     plt.plot(elevation,area_20km, color ='r', label='20km')
     plt.plot(elevation,area_500km, color ='g', label='500km')
-    # plt.plot(elevation,area_35786km, color ='b', label='35786km')
+    plt.plot(elevation,area_35786km, color ='b', label='35786km')
     plt.xlabel('Elevation [deg]')
     plt.ylabel('Footprint area [$km^2$]')
     plt.legend(loc='upper right')

--- a/sharc/support/footprint.py
+++ b/sharc/support/footprint.py
@@ -9,7 +9,6 @@ from area import area as earthArea
 from numpy import cos, sin, tan, arctan, deg2rad, rad2deg, arccos, pi, linspace, arcsin, vstack, arctan2, where, zeros_like
 import matplotlib.pyplot as plt
 from sharc.parameters.constants import EARTH_RADIUS
-
 class Footprint(object):
     """
     Defines a satellite footprint region and calculates its area.
@@ -58,8 +57,10 @@ class Footprint(object):
             
         
         self.beam_width_deg = beam_deg
+        
         # sigma is the relation bewtween earth radius and satellite height
         # print(self.sigma) 
+        
         # Convert to radians
         self.elevation_rad = deg2rad(self.elevation_deg)
         self.bore_lat_rad = deg2rad(self.bore_lat_deg)
@@ -72,8 +73,9 @@ class Footprint(object):
         self.bore_tilt = arctan2(sin(self.beta),((1/self.sigma) - cos(self.beta)))
         
         # Maximum tilt and latitute coverage
-        self.max_gamma_rad = deg2rad(8.6833)
-        self.max_beta_rad = deg2rad(81.3164)
+        self.max_beta_rad = arccos(self.sigma) 
+        self.max_gamma_rad = pi/2 - self.max_beta_rad
+        
         
     def calc_beta(self,elev_deg: float):
         """
@@ -171,8 +173,6 @@ class Footprint(object):
         Output:
             a (float): footprint area in km^2
         """
-        
-        #Sob condições ideais, com 90 graus de eleveção, a conta é simplificada como : A = pi * (sat_height * tan(beam_deg * (pi/180))) ^ 2
         
         long, lat = self.calc_footprint(n)
         


### PR DESCRIPTION
This is an example of how to read .yaml files instead of .ini files, for the parameter file input. It includes a converter scripts that should work with our current .ini files, but i couldn't test with every .ini. It is a simple parser, so it should be easy to adapt and expand.
I was not able to make a parameter class python file generator. I think that we still need to use them, due to the sanity checks that each file contains. But type hinting may be redundant now, as the parameters that come from the yaml file already have the correct types, if they are written correctly.