### PR TITLE
fix: StationFactory.generate_imt_base_stations typo for macrocell and hotspot topologies

### DIFF
--- a/sharc/station_factory.py
+++ b/sharc/station_factory.py
@@ -114,7 +114,7 @@ class StationFactory(object):
                                                                param.spurious_emissions)
 
         if param.topology == 'MACROCELL' or param.topology == 'HOTSPOT':
-            imt_base_stations.intesite_dist = param.intersite_distance
+            imt_base_stations.intersite_dist = param.intersite_distance
 
         return imt_base_stations
 


### PR DESCRIPTION
Existe apenas uma ocorrência da palavra escrita assim no projeto inteiro:

![image](https://github.com/user-attachments/assets/274a5063-8967-4542-b266-9514afa91834)

Sendo assim, parece realmente ser um tentativa falha de setar o valor de `intersite_dist`

O nome correto, usado no resto do projeto, é o seguinte:
![image](https://github.com/user-attachments/assets/9e19583f-1ea7-467a-8a15-010f5bd08dce)
