### PR TITLE
hotfix: propagation p619 path loss shape

### DIFF
--- a/sharc/propagation/propagation_p619.py
+++ b/sharc/propagation/propagation_p619.py
@@ -389,9 +389,7 @@ class PropagationP619(Propagation):
             earth_station_antenna_gain,
             is_single_entry_interf,
         )
-        # FIXME: Need this hack because the other IMT propagtion models returns num_bs x num_ue
-        if is_intra_imt:
-            loss = np.transpose(loss)
+
         return loss
 
     @dispatch(np.ndarray, np.ndarray, np.ndarray, dict, bool, np.ndarray, bool)


### PR DESCRIPTION
Ensuring p619 path loss is returned in proper shape.

PR https://github.com/Radio-Spectrum/SHARC/pull/99/files#diff-7abe2e49ffb1d055c811d191af8736880ef10ac1bdb6b5c6a482616e2821e378R354, `simulation.py:354` makes it so this is not necessary anymore