### PR TITLE
Feat/imt subarray antenna

### DIFF
--- a/sharc/antenna/antenna_beamforming_imt.py
+++ b/sharc/antenna/antenna_beamforming_imt.py
@@ -12,10 +12,10 @@ import matplotlib.pyplot as plt
 from sharc.antenna.antenna_element_imt_m2101 import AntennaElementImtM2101
 from sharc.antenna.antenna_element_imt_f1336 import AntennaElementImtF1336
 from sharc.antenna.antenna_element_imt_const import AntennaElementImtConst
+from sharc.antenna.antenna_subarray_imt import AntennaSubarrayIMT
 from sharc.antenna.antenna import Antenna
-from sharc.support.enumerations import StationType
 from sharc.support.named_tuples import AntennaPar
-from sharc.parameters.imt.parameters_antenna_imt import ParametersAntennaImt
+from sharc.parameters.imt.parameters_antenna_imt import ParametersAntennaImt, ParametersAntennaSubarrayImt
 
 
 class AntennaBeamformingImt(Antenna):
@@ -43,7 +43,7 @@ class AntennaBeamformingImt(Antenna):
         minimum_array_gain (float): minimum array gain for beamforming
     """
 
-    def __init__(self, par: AntennaPar, azimuth: float, elevation: float):
+    def __init__(self, par: AntennaPar, azimuth: float, elevation: float, subarray: ParametersAntennaSubarrayImt):
         """
         Constructs an AntennaBeamformingImt object.
         Does not receive angles in local coordinate system.
@@ -58,6 +58,7 @@ class AntennaBeamformingImt(Antenna):
         """
         super().__init__()
         self.param = par
+        self.subarray = None
 
         if (par.element_pattern).upper() == "M2101":
             self.element = AntennaElementImtM2101(par)
@@ -70,6 +71,14 @@ class AntennaBeamformingImt(Antenna):
                 f"ERROR\nantenna element type {par.element_pattern} not supported",
             )
             sys.exit(1)
+
+        if subarray.is_enabled:
+            self.subarray = AntennaSubarrayIMT(
+                element=self.element,
+                eletrical_downtilt=subarray.eletrical_downtilt,
+                n_rows=subarray.n_rows,
+                element_vert_spacing=subarray.element_vert_spacing
+            )
 
         self.azimuth = azimuth
         self.elevation = elevation
@@ -200,12 +209,29 @@ class AntennaBeamformingImt(Antenna):
                 )\
                     + correction_factor[correction_factor_idx[g]]
         else:
-            for g in range(n_direct):
-                gains[g] = self.element.element_pattern(
+            if self.subarray is not None:
+                subarr_g = self.subarray.calculate_gain(
                     lo_phi_vec[g],
                     lo_theta_vec[g],
-                )\
+                )
+
+                gains[g] = subarr_g \
                     + self.adj_correction_factor
+
+                if self.adj_correction_factor != 0:
+                    raise NotImplementedError(
+                        "Not sure how adjacent correction factor should be dealt with when considering subarray.\n"
+                        + "Even though i 'think' it would make no difference"
+                    )
+            else:
+                for g in range(n_direct):
+                    elem_g = self.element.element_pattern(
+                        lo_phi_vec[g],
+                        lo_theta_vec[g],
+                    )
+
+                    gains[g] = elem_g \
+                        + self.adj_correction_factor
 
         gains = np.maximum(gains, self.minimum_array_gain)
 
@@ -290,7 +316,10 @@ class AntennaBeamformingImt(Antenna):
             gain (float): beam gain [dBi]
         """
 
-        element_g = self.element.element_pattern(phi, theta)
+        if self.subarray is None:
+            element_g = self.element.element_pattern(phi, theta)
+        else:
+            element_g = self.subarray.calculate_gain(phi, theta)
 
         v_vec = self._super_position_vector(phi, theta)
 
@@ -407,6 +436,14 @@ class PlotAntennaPattern(object):
                 theta_vec=theta,
                 beams_l=np.zeros_like(phi, dtype=int),
             )
+        elif plot_type == "SUBARRAY":
+            if antenna.subarray is None:
+                print("An attempt to plot antenna subarrays was done, but antenna has no subarray!")
+                return
+            gain = antenna.subarray.calculate_gain(
+                phi,
+                theta,
+            )
 
         top_y_lim = np.ceil(np.max(gain) / 10) * 10
 
@@ -425,6 +462,8 @@ class PlotAntennaPattern(object):
             )
         elif plot_type == "ARRAY":
             ax1.set_title("IMT " + sta_type + " horizontal antenna pattern")
+        elif plot_type == "SUBARRAY":
+            ax1.set_title("IMT " + sta_type + " subarray horizontal antenna pattern")
 
         ax1.set_xlim(-180, 180)
 
@@ -439,6 +478,14 @@ class PlotAntennaPattern(object):
                 phi_vec=phi,
                 theta_vec=theta,
                 beams_l=np.zeros_like(phi, dtype=int),
+            )
+        elif plot_type == "SUBARRAY":
+            if antenna.subarray is None:
+                print("An attempt to plot antenna subarrays was done, but antenna has no subarray!")
+                return
+            gain = antenna.subarray.calculate_gain(
+                phi,
+                theta,
             )
 
         ax2 = fig.add_subplot(122, sharey=ax1)
@@ -455,6 +502,8 @@ class PlotAntennaPattern(object):
             )
         elif plot_type == "ARRAY":
             ax2.set_title("IMT " + sta_type + " vertical antenna pattern")
+        elif plot_type == "SUBARRAY":
+            ax2.set_title("IMT " + sta_type + " subarray vertical antenna pattern")
 
         ax2.set_xlim(0, 180)
         if np.max(gain) > top_y_lim:
@@ -520,7 +569,7 @@ if __name__ == '__main__':
 
     # Plot BS TX radiation patterns
     par = bs_param.get_antenna_parameters()
-    bs_array = AntennaBeamformingImt(par, 0, 0)
+    bs_array = AntennaBeamformingImt(par, 0, 0, bs_param.sub_array)
     f = plot.plot_element_pattern(bs_array, "BS", "ELEMENT")
     # f.savefig(figs_dir + "BS_element.pdf", bbox_inches='tight')
     f = plot.plot_element_pattern(bs_array, "TX", "ARRAY")
@@ -528,7 +577,7 @@ if __name__ == '__main__':
 
     # Plot UE TX radiation patterns
     par = ue_param.get_antenna_parameters()
-    ue_array = AntennaBeamformingImt(par, 0, 0)
+    ue_array = AntennaBeamformingImt(par, 0, 0, ue_param.sub_array)
     plot.plot_element_pattern(ue_array, "UE", "ELEMENT")
     plot.plot_element_pattern(ue_array, "UE", "ARRAY")
 

--- a/sharc/antenna/antenna_beamforming_imt.py
+++ b/sharc/antenna/antenna_beamforming_imt.py
@@ -43,7 +43,10 @@ class AntennaBeamformingImt(Antenna):
         minimum_array_gain (float): minimum array gain for beamforming
     """
 
-    def __init__(self, par: AntennaPar, azimuth: float, elevation: float, subarray: ParametersAntennaSubarrayImt):
+    def __init__(
+         self, par: AntennaPar, azimuth: float, elevation: float,
+         subarray: ParametersAntennaSubarrayImt = ParametersAntennaSubarrayImt(is_enabled=False)
+     ):
         """
         Constructs an AntennaBeamformingImt object.
         Does not receive angles in local coordinate system.

--- a/sharc/antenna/antenna_subarray_imt.py
+++ b/sharc/antenna/antenna_subarray_imt.py
@@ -92,7 +92,7 @@ class AntennaSubarrayIMT(object):
         m = np.arange(self.n_rows) + 1
 
         return 1 / np.sqrt(n_rows) * np.exp(
-            1.0j * 2 * np.pi * (m-1) * dv_sub * np.sin(np.deg2rad(-eletrical_downtilt))
+            1.0j * 2 * np.pi * (m-1) * dv_sub * np.sin(np.deg2rad(eletrical_downtilt))
         )
 
     def _calculate_single_dir_gain(self, phi: float, theta: float):

--- a/sharc/antenna/antenna_subarray_imt.py
+++ b/sharc/antenna/antenna_subarray_imt.py
@@ -1,0 +1,211 @@
+# -*- coding: utf-8 -*-
+import numpy as np
+import typing
+
+from sharc.antenna.antenna_element_imt_m2101 import AntennaElementImtM2101
+
+# Maybe we should consider using a single array to also make the subarrays
+# Equations are basically the same
+# To make it possible, we should probably update the Beamforming so that, when using subarray:
+# - impl doesn't transform coordinates to local twice
+# - impl allows fixed eletrical downtilt (no beamforming in this case?)
+# - parameters are more clearly defined and passed from Parameters class
+class AntennaSubarrayIMT(object):
+    """
+    Implements a Subarray "Element" for IMT antenna.
+    Subarray implementation defined in R23-WP5D-C-0413, Annex 4.2, Table 8.
+    Most equations are already implemented in SHARC beamforming antenna, and M2101 element
+
+    Attributes
+    ----------
+        element: Antenna element to form subarray
+        eletrical: Antenna element to form subarray
+        n_rows: 
+    """
+
+    def __init__(
+        self,
+        *,
+        element: AntennaElementImtM2101,
+        eletrical_downtilt: float,
+        n_rows: int,
+        element_vert_spacing: float
+    ):
+        """
+        Constructs an AntennaElementImt object.
+
+        Parameters
+        ---------
+        """
+        self.element = element
+        self.eletrical_downtilt = eletrical_downtilt
+        self.n_rows = n_rows
+        # self.n_columns = 1
+        self.dv_sub = element_vert_spacing
+
+    def _super_position_vector(
+        self,
+        theta: float,
+        n_rows: int,
+        dv_sub: float
+    ) -> np.array:
+        """
+        Calculates super position vector.
+        Angles are in the local coordinate system.
+
+        Parameters
+        ----------
+            theta (float): elevation angle [degrees]
+            phi (float): azimuth angle [degrees]
+
+        Returns
+        -------
+            v_vec (np.array): superposition vector
+        """
+        r_theta = np.deg2rad(theta)
+
+        m = np.arange(n_rows) + 1
+
+        v_n = np.exp(
+            1.0j * 2 * np.pi * (m[: np.newaxis]-1) * dv_sub * np.cos(r_theta)
+        )
+
+        return v_n
+    
+    def _weight_vector(self, eletrical_downtilt: float, n_rows: int, dv_sub: float) -> np.array:
+        """
+        Calculates weight/sub-array excitation.
+        Angles are in the local coordinate system.
+
+        Parameters
+        ----------
+            phi_tilt (float): eletrical horizontal steering [degrees]
+            theta_tilt (float): eletrical down-tilt steering [degrees]
+
+        Side Effect
+        -------
+            w_vec (np.array): weighting vector
+        Returns
+        -------
+            None
+        """
+        m = np.arange(self.n_rows) + 1
+
+        return 1 / np.sqrt(n_rows) * np.exp(
+            1.0j * 2 * np.pi * (m-1) * dv_sub * np.sin(np.deg2rad(-eletrical_downtilt))
+        )
+
+    def _calculate_single_dir_gain(self, phi: float, theta: float):
+        """
+        There is no beamforming, this is just for better code
+        """
+        elem_g = self.element.element_pattern(
+            phi, theta
+        )
+
+        v_vec = self._super_position_vector(theta, self.n_rows, self.dv_sub)
+
+        w_vec = self._weight_vector(self.eletrical_downtilt, self.n_rows, self.dv_sub)
+
+        array_g = 10 * np.log10(abs(np.sum(np.multiply(v_vec, w_vec)))**2)
+
+        return array_g + elem_g
+    
+    def calculate_gain(
+        self,
+        phi_arr: typing.Union[np.array, float],
+        theta_arr: typing.Union[np.array, float]
+    ) -> typing.Union[np.array, float]:
+        """
+        Calculates the subarray radiation pattern gain.
+        Assumes the angles are already received as local coordinates
+
+        Parameters
+        ----------
+            theta (np.array): elevation angle [degrees]
+            phi (np.array): azimuth angle [degrees]
+
+        Returns
+        -------
+            gain (np.array): element radiation pattern gain value [dBi]
+        """
+        if isinstance(phi_arr, float) and isinstance(theta_arr, float):
+            return self._calculate_single_dir_gain(phi_arr, theta_arr)
+
+        n_direct = len(phi_arr)
+
+        gains = np.zeros(n_direct)
+
+        for i in range(n_direct):
+            gains[i] = self._calculate_single_dir_gain(phi_arr[i], theta_arr[i])
+
+        return gains
+
+if __name__ == '__main__':
+    from sharc.parameters.imt.parameters_antenna_imt import ParametersAntennaImt
+    from sharc.antenna.antenna_beamforming_imt import AntennaBeamformingImt, PlotAntennaPattern
+
+
+    figs_dir = "figs/"
+
+    bs_param = ParametersAntennaImt()
+    bs2_param = ParametersAntennaImt()
+    bs_param.adjacent_antenna_model = "SINGLE_ELEMENT"
+    bs2_param.adjacent_antenna_model = "SINGLE_ELEMENT"
+
+    bs_param.normalization = False
+    bs2_param.normalization = False
+    bs_param.normalization_file = 'beamforming_normalization\\bs_indoor_norm.npz'
+    bs2_param.normalization_file = 'beamforming_normalization\\bs2_norm.npz'
+    bs_param.minimum_array_gain = -200
+    bs2_param.minimum_array_gain = -200
+
+    bs_param.element_pattern = "M2101"
+    bs_param.element_max_g = 6.4
+    bs_param.element_phi_3db = 90
+    bs_param.element_theta_3db = 65
+    bs_param.element_am = 30
+    bs_param.element_sla_v = 30
+    bs_param.n_rows = 16
+    bs_param.n_columns = 8
+    bs_param.subarray.is_enabled = True
+    bs_param.subarray.element_vert_spacing = 0.7
+    bs_param.subarray.eletrical_downtilt = 3
+    bs_param.subarray.n_rows = 3
+    # bs_param.n_rows = 8
+    # bs_param.n_columns = 16
+    bs_param.element_horiz_spacing = 0.5
+    bs_param.element_vert_spacing = 2.1
+    bs_param.multiplication_factor = 12
+    bs_param.downtilt = 0
+
+    bs2_param.element_pattern = "M2101"
+    bs2_param.element_max_g = 6.4
+    bs2_param.element_phi_3db = 90
+    bs2_param.element_theta_3db = 65
+    bs2_param.element_am = 30
+    bs2_param.element_sla_v = 30
+    bs2_param.n_rows = 3
+    bs2_param.n_columns = 1
+    bs2_param.element_horiz_spacing = 0.5
+    bs2_param.element_vert_spacing = 0.7
+    bs2_param.multiplication_factor = 12
+
+    plot = PlotAntennaPattern(figs_dir)
+
+    # Plot BS TX radiation patterns
+    par = bs_param.get_antenna_parameters()
+    bs_array = AntennaBeamformingImt(par, 0, 0, bs_param.subarray)
+    f = plot.plot_element_pattern(bs_array, "BS", "ELEMENT")
+    # f.savefig(figs_dir + "BS_element.pdf", bbox_inches='tight')
+    f = plot.plot_element_pattern(bs_array, "BS", "SUBARRAY")
+    f = plot.plot_element_pattern(bs_array, "BS", "ARRAY")
+    # f.savefig(figs_dir + "BS_array.pdf", bbox_inches='tight')
+
+    # Plot UE TX radiation patterns
+    par = bs2_param.get_antenna_parameters()
+    bs2_array = AntennaBeamformingImt(par, 0, 0, bs2_param.subarray)
+    # plot.plot_element_pattern(bs2_array, "BS 2", "ELEMENT")
+    # plot.plot_element_pattern(bs2_array, "BS 2", "ARRAY")
+
+    print('END')

--- a/sharc/antenna/antenna_subarray_imt.py
+++ b/sharc/antenna/antenna_subarray_imt.py
@@ -4,6 +4,7 @@ import typing
 
 from sharc.antenna.antenna_element_imt_m2101 import AntennaElementImtM2101
 
+
 # Maybe we should consider using a single array to also make the subarrays
 # Equations are basically the same
 # To make it possible, we should probably update the Beamforming so that, when using subarray:
@@ -20,7 +21,7 @@ class AntennaSubarrayIMT(object):
     ----------
         element: Antenna element to form subarray
         eletrical: Antenna element to form subarray
-        n_rows: 
+        n_rows: How many rows subarray has
     """
 
     def __init__(
@@ -67,11 +68,11 @@ class AntennaSubarrayIMT(object):
         m = np.arange(n_rows) + 1
 
         v_n = np.exp(
-            1.0j * 2 * np.pi * (m[: np.newaxis]-1) * dv_sub * np.cos(r_theta)
+            1.0j * 2 * np.pi * (m[: np.newaxis] - 1) * dv_sub * np.cos(r_theta)
         )
 
         return v_n
-    
+
     def _weight_vector(self, eletrical_downtilt: float, n_rows: int, dv_sub: float) -> np.array:
         """
         Calculates weight/sub-array excitation.
@@ -92,7 +93,7 @@ class AntennaSubarrayIMT(object):
         m = np.arange(self.n_rows) + 1
 
         return 1 / np.sqrt(n_rows) * np.exp(
-            1.0j * 2 * np.pi * (m-1) * dv_sub * np.sin(np.deg2rad(eletrical_downtilt))
+            1.0j * 2 * np.pi * (m - 1) * dv_sub * np.sin(np.deg2rad(eletrical_downtilt))
         )
 
     def _calculate_single_dir_gain(self, phi: float, theta: float):
@@ -110,7 +111,7 @@ class AntennaSubarrayIMT(object):
         array_g = 10 * np.log10(abs(np.sum(np.multiply(v_vec, w_vec)))**2)
 
         return array_g + elem_g
-    
+
     def calculate_gain(
         self,
         phi_arr: typing.Union[np.array, float],
@@ -141,10 +142,10 @@ class AntennaSubarrayIMT(object):
 
         return gains
 
+
 if __name__ == '__main__':
     from sharc.parameters.imt.parameters_antenna_imt import ParametersAntennaImt
     from sharc.antenna.antenna_beamforming_imt import AntennaBeamformingImt, PlotAntennaPattern
-
 
     figs_dir = "figs/"
 

--- a/sharc/input/parameters.yaml
+++ b/sharc/input/parameters.yaml
@@ -261,6 +261,19 @@ imt:
             # side lobes when beamforming is assumed in adjacent channel.
             #       Original value: 12 (Rec. ITU-R M.2101)
             multiplication_factor: 12
+            ###########################################################################
+            # Subarray for IMT as defined in R23-WP5D-C-0413, Annex 4.2
+            # Single column sub array
+            subarray:
+                # NOTE: if subarray is enabled, element definition will mostly come from
+                # the above definitions
+                is_enabled: false
+                # Rows per subarray
+                n_rows: 3
+                # Sub array element spacing (d/lambda).
+                element_vert_spacing: 0.7
+                # Sub array eletrical downtilt [deg]
+                eletrical_downtilt: 3.0
 
     ###########################################################################
     # User Equipment parameters:

--- a/sharc/parameters/imt/parameters_antenna_imt.py
+++ b/sharc/parameters/imt/parameters_antenna_imt.py
@@ -9,8 +9,28 @@ from sharc.support.named_tuples import AntennaPar
 from numpy import load
 import typing
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from sharc.parameters.parameters_base import ParametersBase
+
+
+@dataclass
+class ParametersAntennaSubarrayImt(ParametersBase):
+    """
+    Parameters for subarray as defined in R23-WP5D-C-0413, Annex 4.2
+    """
+    # to use subarray, set this to true
+    is_enabled: bool = False
+
+    # Number of rows in subarray
+    n_rows: int = 3
+
+    # BS array element vertical spacing (d/lambda).
+    element_vert_spacing: float = 0.5
+    # element_vert_spacing: float = 0.5
+
+    # notice that electrical tilt == -1 * downtilt
+    # Sub array eletrical downtilt [deg]
+    eletrical_downtilt: float = 3.0
 
 
 @dataclass
@@ -62,6 +82,8 @@ class ParametersAntennaImt(ParametersBase):
     multiplication_factor: int = 12
 
     adjacent_antenna_model: typing.Literal["BEAMFORMING", "SINGLE_ELEMENT"] = None
+
+    subarray: ParametersAntennaSubarrayImt = field(default_factory=ParametersAntennaSubarrayImt)
 
     def load_subparameters(self, ctx: str, params: dict, quiet=True):
         """

--- a/sharc/simulation.py
+++ b/sharc/simulation.py
@@ -150,15 +150,11 @@ class Simulation(ABC, Observable):
 
         self.bs_power_gain = 10 * math.log10(
             self.parameters.imt.bs.antenna.n_rows *
-            self.parameters.imt.bs.antenna.n_columns *
-            (self.parameters.imt.bs.antenna.subarray.n_rows
-                if self.parameters.imt.bs.antenna.subarray.is_enabled else 1),
+            self.parameters.imt.bs.antenna.n_columns,
         )
         self.ue_power_gain = 10 * math.log10(
             self.parameters.imt.ue.antenna.n_rows *
-            self.parameters.imt.ue.antenna.n_columns *
-            (self.parameters.imt.ue.antenna.subarray.n_rows
-                    if self.parameters.imt.ue.antenna.subarray.is_enabled else 1),
+            self.parameters.imt.ue.antenna.n_columns,
         )
         self.imt_bs_antenna_gain = list()
         self.imt_ue_antenna_gain = list()

--- a/sharc/simulation.py
+++ b/sharc/simulation.py
@@ -150,11 +150,15 @@ class Simulation(ABC, Observable):
 
         self.bs_power_gain = 10 * math.log10(
             self.parameters.imt.bs.antenna.n_rows *
-            self.parameters.imt.bs.antenna.n_columns,
+            self.parameters.imt.bs.antenna.n_columns *
+            (self.parameters.imt.bs.antenna.subarray.n_rows
+                if self.parameters.imt.bs.antenna.subarray.is_enabled else 1),
         )
         self.ue_power_gain = 10 * math.log10(
             self.parameters.imt.ue.antenna.n_rows *
-            self.parameters.imt.ue.antenna.n_columns,
+            self.parameters.imt.ue.antenna.n_columns *
+            (self.parameters.imt.ue.antenna.subarray.n_rows
+                    if self.parameters.imt.ue.antenna.subarray.is_enabled else 1),
         )
         self.imt_bs_antenna_gain = list()
         self.imt_ue_antenna_gain = list()

--- a/sharc/station_factory.py
+++ b/sharc/station_factory.py
@@ -122,7 +122,8 @@ class StationFactory(object):
             imt_base_stations.antenna[i] = \
                 AntennaBeamformingImt(
                     param_ant, imt_base_stations.azimuth[i],
-                    imt_base_stations.elevation[i],)
+                    imt_base_stations.elevation[i], param_ant_bs.subarray
+                )
 
         # imt_base_stations.antenna = [AntennaOmni(0) for bs in range(num_bs)]
         imt_base_stations.bandwidth = param.bandwidth * np.ones(num_bs)
@@ -337,7 +338,7 @@ class StationFactory(object):
         for i in range(num_ue):
             imt_ue.antenna[i] = AntennaBeamformingImt(
                 par, imt_ue.azimuth[i],
-                imt_ue.elevation[i],
+                imt_ue.elevation[i], ue_param_ant.subarray
             )
 
         # imt_ue.antenna = [AntennaOmni(0) for bs in range(num_ue)]
@@ -494,7 +495,7 @@ class StationFactory(object):
         for i in range(num_ue):
             imt_ue.antenna[i] = AntennaBeamformingImt(
                 par, imt_ue.azimuth[i],
-                imt_ue.elevation[i],
+                imt_ue.elevation[i], ue_param_ant.subarray
             )
 
         # imt_ue.antenna = [AntennaOmni(0) for bs in range(num_ue)]

--- a/tests/parameters/parameters_for_testing.yaml
+++ b/tests/parameters/parameters_for_testing.yaml
@@ -261,6 +261,19 @@ imt:
             # side lobes when beamforming is assumed in adjacent channel.
             #       Original value: 12 (Rec. ITU-R M.2101)
             multiplication_factor  : 12
+            ###########################################################################
+            # Subarray for IMT as defined in R23-WP5D-C-0413, Annex 4.2
+            # Single column sub array
+            subarray:
+                # NOTE: if subarray is enabled, element definition will mostly come from
+                # the above definitions
+                is_enabled: true
+                # Rows per subarray
+                n_rows: 10
+                # Sub array element spacing (d/lambda).
+                element_vert_spacing: 0.05
+                # Sub array eletrical downtilt [deg]
+                eletrical_downtilt: 9.0
 
     ###########################################################################
     # User Equipment parameters:

--- a/tests/parameters/test_parameters.py
+++ b/tests/parameters/test_parameters.py
@@ -112,6 +112,25 @@ class ParametersTest(unittest.TestCase):
         self.assertEqual(
             self.parameters.imt.ue.antenna.multiplication_factor, 12)
 
+        """Test ParametersSubarrayImt
+        """
+        # testing default value not enabled
+        self.assertEqual(
+            self.parameters.imt.ue.antenna.subarray.is_enabled, False
+        )
+        # testing a fictitious configuration
+        self.assertEqual(
+            self.parameters.imt.bs.antenna.subarray.is_enabled, True
+        )
+        self.assertEqual(
+            self.parameters.imt.bs.antenna.subarray.eletrical_downtilt, 9
+        )
+        self.assertEqual(
+            self.parameters.imt.bs.antenna.subarray.n_rows, 10
+        )
+        self.assertEqual(
+            self.parameters.imt.bs.antenna.subarray.element_vert_spacing, 0.05
+        )
         """Test ParametersHotspot
         """
         self.assertEqual(self.parameters.imt.topology.hotspot.num_hotspots_per_cell, 1)


### PR DESCRIPTION
Implementation according to **Document R23-WP5D-C-0413**, which is the same as **Annex 4.2 to Document 5D/413-E​**, Table 8. It is mostly the same as 2101 definition, with a subarray calculation added.

![image](https://github.com/user-attachments/assets/5670b9b7-47d5-456e-963e-ebc5b04c8cbd)


## Done

- Added single column subarray implementation to IMT antenna;
- Added tests for Subarray Parameters;
- Added subarray plot implementation;

## Missing:
- Unit tests for subarray implementation;
- correction factor when using subarray (don't even know what it means);

## TODO?:
Maybe could be better to refactor the IMT antenna to **separate beamforming from array** implementation. If implemented separately, subarray and array implementation would be **exactly the same**, since their formulas for aggregating gain are the same, with the only difference is that the subarray has a constant electrical tilt instead of using it for beamforming.

Example API:
```py
class BeamformingAntenna():
    self.array = Array(sub_array=Array(electrilcal_theta_downtilt=3, element=Element2101(...)))
    # or
    self.array = Array(element=Element2101(...))

    def add_beam(self, phi, theta):
        # since weight and superposition vector are array implementations
        # should memoize them there if don't want to recalculate
        self.beams_list.append((phi, theta))
    
    def calculate_gains():
        for i, phi, theta in zip(something):
            g[i] = self.array.gain(
                self.transform_coordinates_to_local(phi, theta)
            )
```