### PR TITLE
Feat/mss partial overlap on ues

### DIFF
--- a/sharc/campaigns/mss_d2d_to_imt/input/parameters_mss_d2d_to_imt_co_channel_system_A.yaml
+++ b/sharc/campaigns/mss_d2d_to_imt/input/parameters_mss_d2d_to_imt_co_channel_system_A.yaml
@@ -43,6 +43,8 @@ imt:
     ###########################################################################
     # IMT resource block bandwidth [MHz]
     rb_bandwidth: 0.180
+    # IMT resource block bandwidth [MHz]
+    adjacent_ch_reception: ACS
     ###########################################################################
     # IMT spectrum emission mask. Options are:
     #   "IMT-2020" : for mmWave as described in ITU-R TG 5/1 Contribution 36
@@ -468,6 +470,9 @@ imt:
 mss_d2d:
     # MSS_D2D system name
     name: SystemA
+    # Adjacent channel emissions type
+    # Possible values are "ACLR", "SPECTRAL_MASK" and "OFF"
+    adjacent_ch_emissions: ACLR
     # MSS_D2D system center frequency in MHz
     frequency: 2170.0
     # MSS_D2d system bandwidth in MHz

--- a/sharc/campaigns/mss_d2d_to_imt/input/parameters_mss_d2d_to_imt_co_channel_system_A.yaml
+++ b/sharc/campaigns/mss_d2d_to_imt/input/parameters_mss_d2d_to_imt_co_channel_system_A.yaml
@@ -472,7 +472,9 @@ mss_d2d:
     name: SystemA
     # Adjacent channel emissions type
     # Possible values are "ACLR", "SPECTRAL_MASK" and "OFF"
-    adjacent_ch_emissions: ACLR
+    adjacent_ch_emissions: SPECTRAL_MASK
+    # chosen spectral Mask
+    spectral_mask: MSS
     # MSS_D2D system center frequency in MHz
     frequency: 2170.0
     # MSS_D2d system bandwidth in MHz

--- a/sharc/mask/spectral_mask_mss.py
+++ b/sharc/mask/spectral_mask_mss.py
@@ -84,8 +84,6 @@ class SpectralMaskMSS(SpectralMask):
         # this should work for the document's dBsd definition
         # when we have a uniform PSD in assigned band
         self.p_tx = p_tx - 10 * np.log10(self.band_mhz) + 30
-        # print("self.p_tx", self.p_tx)
-        # print("10 * np.log10(0.1 * self.p_tx)", 10 ** ((p_tx - 10 * np.log10(self.band_mhz * 1e6)) / 10))
 
         # attenuation mask
         mask_dbsd = 40 * np.log10(
@@ -93,7 +91,6 @@ class SpectralMaskMSS(SpectralMask):
             100 * (self.delta_f_lim[:-1] / self.band_mhz) / 50 + 1
             # 100 * ((self.delta_f_lim[:-1] + self.reference_bandwidth/2) / self.band_mhz) / 50 + 1
         )
-        # print("mask_dbsd", mask_dbsd)
 
         # functionally same as 0, but won't be ignored at spectral mask calculation
         # TODO: something better than this...
@@ -103,22 +100,17 @@ class SpectralMaskMSS(SpectralMask):
 
         mask_dbm = np.concatenate((mask_dbm, [self.spurious_emissions]))
 
-        # we should set the center p_tx as zero only so that we consider
-        # co-channel separate from adjacent channel on simulation
         self.mask_dbm = np.concatenate((
             mask_dbm[::-1],
             np.array([self.p_tx]),
             mask_dbm,
         ))
 
-        # print("self.mask_dbm", self.mask_dbm)
-        # print("self.freq_lim", self.freq_lim)
-
 
 if __name__ == '__main__':
     # Initialize variables
     p_tx = 34.061799739838875
-    freq = 9000
+    freq = 2100
     band = 5
     spurious_emissions_dbm_mhz = -30
 

--- a/sharc/mask/spectral_mask_mss.py
+++ b/sharc/mask/spectral_mask_mss.py
@@ -1,0 +1,158 @@
+# -*- coding: utf-8 -*-
+
+from sharc.support.enumerations import StationType
+from sharc.mask.spectral_mask import SpectralMask
+
+import numpy as np
+import math
+import matplotlib.pyplot as plt
+
+
+class SpectralMaskMSS(SpectralMask):
+    """
+    Implements spectral mask for all MSS Space Stations and some MSS Earth Stations
+    according to REC ITU-R SM.1541. This is a generic mask and should only be used in case
+    another isn't given.
+
+    Spurious boundary has a default of 200% of the bandwidth from band edge.
+
+    Attributes:
+        spurious_emissions (float): level of power emissions at spurious
+            domain [dBm/MHz].
+        delta_f_lin (np.array): mask delta f breaking limits in MHz. Delta f
+            values for which the spectral mask changes value. In this context, delta f is the frequency distance to
+            the transmission's edge frequencies
+        freq_lim (no.array): frequency values for which the spectral mask
+            changes emission value
+        freq_mhz (float): center frequency of station in MHz
+        band_mhs (float): transmitting bandwidth of station in MHz
+        p_tx (float): station's transmit power in dBm/MHz
+        mask_dbm (np.array): spectral mask emission values in dBm
+    """
+
+    ALREADY_WARNED_AGAINST_LONG_CALCULATIONS = False
+    def __init__(
+        self,
+        freq_mhz: float,
+        band_mhz: float,
+        spurious_emissions: float,
+    ):
+        """
+        Class constructor.
+
+        Parameters:
+            freq_mhz (float): center frequency of station in MHz
+            band_mhs (float): transmitting bandwidth of station in MHz
+            spurious_emissions (float): level of spurious emissions [dBm/MHz].
+        """
+        # Spurious domain limits [dBm/MHz]
+        self.spurious_emissions = spurious_emissions
+
+        if freq_mhz < 15000:
+            if band_mhz > 20 and not self.ALREADY_WARNED_AGAINST_LONG_CALCULATIONS:
+                self.ALREADY_WARNED_AGAINST_LONG_CALCULATIONS = True
+                print("WARNING: SpectralMaskMSS may take noticeably long to calculate. Consider changing its integral step.")
+            self.reference_bandwidth = 0.004
+        else:
+            self.reference_bandwidth = 1
+        self.spurious_boundary = 2 * band_mhz
+
+        self.delta_f_lim = np.linspace(
+            0., self.spurious_boundary - self.reference_bandwidth,
+            math.ceil(self.spurious_boundary / self.reference_bandwidth)
+        )
+        self.delta_f_lim = np.concatenate((self.delta_f_lim, [self.spurious_boundary]))
+
+        # Attributes
+        self.band_mhz = band_mhz
+        self.freq_mhz = freq_mhz
+
+        self.freq_lim = np.concatenate((
+            (freq_mhz - band_mhz / 2) - self.delta_f_lim[::-1],
+            (freq_mhz + band_mhz / 2) + self.delta_f_lim,
+        ))
+
+    def set_mask(self, p_tx):
+        """
+        Sets the spectral mask (mask_dbm attribute) based on station type,
+        operating frequency and transmit power.
+
+        Parameters:
+            p_tx (float): station transmit power.
+        """
+        # dBm/MHz
+        # this should work for the document's dBsd definition
+        # when we have a uniform PSD in assigned band
+        self.p_tx = p_tx - 10 * np.log10(self.band_mhz) + 30
+        # print("self.p_tx", self.p_tx)
+        # print("10 * np.log10(0.1 * self.p_tx)", 10 ** ((p_tx - 10 * np.log10(self.band_mhz * 1e6)) / 10))
+
+        # attenuation mask
+        mask_dbsd = 40 * np.log10(
+            # both in MHz, percentage is just division
+            100 * (self.delta_f_lim[:-1] / self.band_mhz) / 50 + 1
+            # 100 * ((self.delta_f_lim[:-1] + self.reference_bandwidth/2) / self.band_mhz) / 50 + 1
+        )
+        # print("mask_dbsd", mask_dbsd)
+
+        # functionally same as 0, but won't be ignored at spectral mask calculation
+        # TODO: something better than this...
+        mask_dbsd[mask_dbsd == 0.] = 1e-14
+
+        mask_dbm = self.p_tx - mask_dbsd
+
+        mask_dbm = np.concatenate((mask_dbm, [self.spurious_emissions]))
+
+        # we should set the center p_tx as zero only so that we consider
+        # co-channel separate from adjacent channel on simulation
+        self.mask_dbm = np.concatenate((
+            mask_dbm[::-1],
+            np.array([self.p_tx]),
+            mask_dbm,
+        ))
+
+        # print("self.mask_dbm", self.mask_dbm)
+        # print("self.freq_lim", self.freq_lim)
+
+
+if __name__ == '__main__':
+    # Initialize variables
+    p_tx = 34.061799739838875
+    freq = 9000
+    band = 5
+    spurious_emissions_dbm_mhz = -30
+
+    # Create mask
+    msk = SpectralMaskMSS(freq, band, spurious_emissions_dbm_mhz)
+    msk.set_mask(p_tx)
+
+    # Frequencies
+    freqs = np.linspace(-15, 15, num=1000) + freq
+
+    # Mask values
+    mask_val = np.ones_like(freqs) * msk.mask_dbm[0]
+    for k in range(len(msk.freq_lim) - 1, -1, -1):
+        mask_val[np.where(freqs < msk.freq_lim[k])] = msk.mask_dbm[k]
+        # set as p_tx instead of 0 for plotting
+        if k == len(msk.delta_f_lim):
+            mask_val[np.where(freqs < msk.freq_lim[k])] = msk.p_tx
+
+    # Plot
+    # plt.plot(freqs, 10**(mask_val/10))
+    plt.plot(freqs, mask_val)
+    plt.xlim([freqs[0], freqs[-1]])
+    plt.xlabel(r"f [MHz]")
+    plt.ylabel("Spectral Mask [dBm]")
+    plt.grid()
+    plt.show()
+
+    oob_idxs = np.where((freqs > freq - msk.spurious_boundary) & (freqs < freq + msk.spurious_boundary))[0]
+
+    # Plot
+    plt.plot(freqs[oob_idxs], mask_val[oob_idxs])
+    # plt.plot(freqs[oob_idxs], 10 **(mask_val[oob_idxs]/10))
+    plt.xlim([freqs[oob_idxs][0], freqs[oob_idxs][-1]])
+    plt.xlabel(r"f [MHz]")
+    plt.ylabel("Spectral Mask before spurious region [mW]")
+    plt.grid()
+    plt.show()

--- a/sharc/parameters/imt/parameters_imt.py
+++ b/sharc/parameters/imt/parameters_imt.py
@@ -26,10 +26,8 @@ class ParametersImt(ParametersBase):
     spectral_mask: str = "IMT-2020"
     spurious_emissions: float = -13.0
     guard_band_ratio: float = 0.1
-    # Adjacent Interference model used when IMT is victim. Possible values are ACIR or SPECTRAL_MASK.
-    # When using ACIR the interfence power from the other system is calculted by using the ACLR and ACS.
-    # Whith the SPECTRAL_MASK the the interference power from the other system is calculated from it's spectral mask.
-    adjacent_interf_model: str = "ACIR"
+    # Adjacent Interference filter reception used when IMT is victim. Possible values is ACS and OFF
+    adjacent_ch_reception: str = "OFF"
     @dataclass
     class ParametersBS(ParametersBase):
         load_probability = 0.2
@@ -131,6 +129,10 @@ class ParametersImt(ParametersBase):
         if self.spectral_mask not in ["IMT-2020", "3GPP E-UTRA"]:
             raise ValueError(
                 f"""ParametersImt: Inavlid Spectral Mask Name {self.spectral_mask}""",
+            )
+        if self.adjacent_ch_reception not in ["ACS"]:
+            raise ValueError(
+                f"""ParametersImt: Invalid Adjacent Channel Reception model {self.adjacent_ch_reception}""",
             )
 
         if self.channel_model not in ["FSPL", "CI", "UMa", "UMi", "TVRO-URBAN", "TVRO-SUBURBAN", "ABG", "P619"]:

--- a/sharc/parameters/parameters_mss_d2d.py
+++ b/sharc/parameters/parameters_mss_d2d.py
@@ -28,6 +28,10 @@ class ParametersMssD2d(ParametersBase):
     # MSS_D2d system bandwidth in MHz
     bandwidth: float = 5.0
 
+    # Adjacent channel emissions type
+    # Possible values are "ACLR", "SPECTRAL_MASK" and "OFF"
+    adjacent_ch_emissions: str = "OFF"
+
     # Transmitter spectral mask
     spectral_mask: str = "3GPP E-UTRA"
 
@@ -105,6 +109,9 @@ class ParametersMssD2d(ParametersBase):
             raise ValueError(f"ParametersMssD2d: cell_radius must be greater than 0, but is {self.cell_radius}")
         else:
             self.intersite_distance = np.sqrt(3) * self.cell_radius
+
+        if self.adjacent_ch_emissions not in ["SPECTRAL_MASK", "ACLR", "OFF"]:
+            raise ValueError(f"""ParametersMssD2d: Invalid adjacent channel emissions {self.adjacent_ch_emissions}""")
 
         if self.spectral_mask.upper() not in ["IMT-2020", "3GPP E-UTRA"]:
             raise ValueError(f"""ParametersMssD2d: Inavlid Spectral Mask Name {self.spectral_mask}""")

--- a/sharc/parameters/parameters_mss_d2d.py
+++ b/sharc/parameters/parameters_mss_d2d.py
@@ -33,7 +33,7 @@ class ParametersMssD2d(ParametersBase):
     adjacent_ch_emissions: str = "OFF"
 
     # Transmitter spectral mask
-    spectral_mask: str = "3GPP E-UTRA"
+    spectral_mask: str = "MSS"
 
     # Out-of-band spurious emissions in dB/MHz
     spurious_emissions: float = -13.0
@@ -113,7 +113,7 @@ class ParametersMssD2d(ParametersBase):
         if self.adjacent_ch_emissions not in ["SPECTRAL_MASK", "ACLR", "OFF"]:
             raise ValueError(f"""ParametersMssD2d: Invalid adjacent channel emissions {self.adjacent_ch_emissions}""")
 
-        if self.spectral_mask.upper() not in ["IMT-2020", "3GPP E-UTRA"]:
+        if self.spectral_mask.upper() not in ["IMT-2020", "3GPP E-UTRA", "MSS"]:
             raise ValueError(f"""ParametersMssD2d: Inavlid Spectral Mask Name {self.spectral_mask}""")
 
         self.antenna_s1528.set_external_parameters(antenna_pattern=self.antenna_pattern,

--- a/sharc/simulation.py
+++ b/sharc/simulation.py
@@ -559,7 +559,7 @@ class Simulation(ABC, Observable):
 
         return tput
 
-    def calculate_bw_weights(self, bw_imt: float, bw_sys: float, ue_k: int) -> np.array:
+    def calculate_bw_weights(self, bw_ue: np.array, fc_ue: np.array, bw_sys: float, fc_sys: float) -> np.array:
         """
         Calculates the weight that each resource block group of IMT base stations
         will have when estimating the interference to other systems based on
@@ -576,26 +576,26 @@ class Simulation(ABC, Observable):
         -------
             K-dimentional array of weights
         """
+        ue_min_f = fc_ue - bw_ue/2
+        ue_max_f = fc_ue + bw_ue/2
 
-        if bw_imt <= bw_sys:
-            weights = np.ones(ue_k)
+        sys_min_f = fc_sys - bw_sys/2
+        sys_max_f = fc_sys + bw_sys/2
 
-        elif bw_imt > bw_sys:
-            weights = np.zeros(ue_k)
+        # print("ue_min_f", ue_min_f)
+        # print("ue_max_f", ue_max_f)
+        # print("sys_min_f", sys_min_f)
+        # print("sys_max_f", sys_max_f)
 
-            bw_per_rbg = bw_imt / ue_k
+        overlap = np.maximum(
+            0,
+            np.minimum(ue_max_f, sys_max_f) - np.maximum(ue_min_f, sys_min_f)
+        ) / bw_ue
+        # print("fc_ue", fc_ue)
+        # print("overlap", overlap)
+        # exit()
 
-            # number of resource block groups that will have weight equal to 1
-            rb_ones = math.floor(bw_sys / bw_per_rbg)
-
-            # weight of the rbg that will generate partial interference
-            rb_partial = np.mod(bw_sys, bw_per_rbg) / bw_per_rbg
-
-            # assign value to weight array
-            weights[:rb_ones] = 1
-            weights[rb_ones] = rb_partial
-
-        return weights
+        return overlap
 
     def plot_scenario(self):
         fig = plt.figure(figsize=(8, 8), facecolor='w', edgecolor='k')

--- a/sharc/simulation.py
+++ b/sharc/simulation.py
@@ -437,6 +437,11 @@ class Simulation(ABC, Observable):
                 self.parameters.imt.rb_bandwidth
             self.ue.bandwidth[ue] = self.num_rb_per_ue * \
                 self.parameters.imt.rb_bandwidth
+            self.ue.center_freq[ue] = np.array([
+                    self.parameters.imt.frequency
+                    + self.num_rb_per_ue * self.parameters.imt.rb_bandwidth * (i - (len(ue) - 1)/2)
+                    for i in range(len(ue))
+                ])
 
     def calculate_gains(
         self,

--- a/sharc/simulation_downlink.py
+++ b/sharc/simulation_downlink.py
@@ -266,6 +266,14 @@ class SimulationDownlink(Simulation):
                 # could use different coupling loss if
                 # different antenna pattern is to be considered on adj channel
                 oob_power -= self.coupling_loss_imt_system[ue, :][:, active_sys]
+            else:
+                oob_power = np.tile(
+                    np.reshape(
+                        oob_power,
+                        (-1, 1)
+                    ),
+                    (1, len(active_sys))
+                )
 
             # Total external interference into the UE in dBm
             ue_ext_int = 10 * np.log10(np.power(10, 0.1 * in_band_interf_power) + np.power(10, 0.1 * oob_power))

--- a/sharc/simulation_downlink.py
+++ b/sharc/simulation_downlink.py
@@ -163,12 +163,13 @@ class SimulationDownlink(Simulation):
 
             # Get the weight factor for the system overlaping bandwidth in each UE band.
             weights = self.calculate_bw_weights(
-                self.parameters.imt.bandwidth,
-                self.overlapping_bandwidth,
-                self.parameters.imt.ue.k
+                self.ue.bandwidth,
+                self.ue.center_freq,
+                float(self.param_system.bandwidth),
+                float(self.param_system.frequency),
             )
 
-            in_band_interf_power = np.resize(-500, len(ue))
+            in_band_interf_power = np.resize(-500., len(ue))
             if self.co_channel:
                 # Inteferer transmit power in dBm over the overlapping band (MHz) with UEs.
                 if self.overlapping_bandwidth > 0:
@@ -179,19 +180,16 @@ class SimulationDownlink(Simulation):
                             self.ue.bandwidth[ue, np.newaxis] * 1e6
                         ) + 10 * np.log10(weights)[:, np.newaxis] - self.coupling_loss_imt_system[ue, :][:, active_sys]
 
-            oob_power = np.resize(-500, len(ue))
+            oob_power = np.resize(-500., len(ue))
             if self.adjacent_channel:
-                # adj_weights is the factor of how much of the rx bw doesn't overlap with tx bw
-                adj_weights = 1. - weights
-
                 # emissions outside of tx bandwidth and inside of rx bw
                 # due to oob emissions on tx side
-                tx_oob = np.resize(-500, len(ue))
+                tx_oob = np.resize(-500., len(ue))
 
                 # emissions outside of rx bw and inside of tx bw
                 # due to non ideal filtering on rx side
                 # will be the same for all UE's, only considering
-                rx_oob = np.resize(-500, len(ue))
+                rx_oob = np.resize(-500., len(ue))
 
                 # TODO: M.2101 states that:
                 # "The ACIR value should be calculated based on per UE allocated number of resource blocks"
@@ -206,7 +204,6 @@ class SimulationDownlink(Simulation):
                 # should interfer ^        less than this ^
 
                 # Unless we never use ACS..?
-
                 if self.parameters.imt.adjacent_ch_reception == "ACS":
                     if self.overlapping_bandwidth > 0:
                         if not hasattr(self, "ALREADY_WARNED_ABOUT_ACS_WHEN_OVERLAPPING_BAND"):
@@ -327,9 +324,10 @@ class SimulationDownlink(Simulation):
                 if self.overlapping_bandwidth:
                     acs = 0
                     weights = self.calculate_bw_weights(
-                        self.parameters.imt.bandwidth,
+                        self.ue.bandwidth,
+                        self.ue.center_freq,
                         self.param_system.bandwidth,
-                        self.parameters.imt.ue.k,
+                        self.param_system.frequency,
                     )
                 else:
                     acs = self.param_system.adjacent_ch_selectivity

--- a/sharc/simulation_downlink.py
+++ b/sharc/simulation_downlink.py
@@ -179,6 +179,14 @@ class SimulationDownlink(Simulation):
                         self.param_system.tx_power_density + 10 * np.log10(
                             self.ue.bandwidth[ue, np.newaxis] * 1e6
                         ) + 10 * np.log10(weights)[:, np.newaxis] - self.coupling_loss_imt_system[ue, :][:, active_sys]
+            else:
+                in_band_interf_power = np.tile(
+                    np.reshape(
+                        in_band_interf_power,
+                        (-1, 1)
+                    ),
+                    (1, len(active_sys))
+                )
 
             oob_power = np.resize(-500., len(ue))
             if self.adjacent_channel:

--- a/sharc/simulation_downlink.py
+++ b/sharc/simulation_downlink.py
@@ -160,39 +160,115 @@ class SimulationDownlink(Simulation):
         bs_active = np.where(self.bs.active)[0]
         for bs in bs_active:
             ue = self.link[bs]
-            in_band_interf_power = -500
+
+            # Get the weight factor for the system overlaping bandwidth in each UE band.
+            weights = self.calculate_bw_weights(
+                self.parameters.imt.bandwidth,
+                self.overlapping_bandwidth,
+                self.parameters.imt.ue.k
+            )
+
+            in_band_interf_power = np.resize(-500, len(ue))
             if self.co_channel:
+                # Inteferer transmit power in dBm over the overlapping band (MHz) with UEs.
                 if self.overlapping_bandwidth > 0:
-                    # Inteferer transmit power in dBm over the overlapping band (MHz) with UEs.
-                    # Get the weight factor for the system overlaping bandwidth in each UE band.
-                    weights = self.calculate_bw_weights(
-                        self.parameters.imt.bandwidth,
-                        self.overlapping_bandwidth,
-                        self.parameters.imt.ue.k)
                     # in_band_interf_power = self.param_system.tx_power_density + \
                     #     10 * np.log10(self.overlapping_bandwidth * 1e6) + 30
                     in_band_interf_power = \
-                        self.param_system.tx_power_density + 10 * np.log10(self.ue.bandwidth[ue, np.newaxis] * 1e6) + \
-                        10 * np.log10(weights)[:, np.newaxis] - self.coupling_loss_imt_system[ue, :][:, active_sys]
+                        self.param_system.tx_power_density + 10 * np.log10(
+                            self.ue.bandwidth[ue, np.newaxis] * 1e6
+                        ) + 10 * np.log10(weights)[:, np.newaxis] - self.coupling_loss_imt_system[ue, :][:, active_sys]
 
-            oob_power = -500
-            oob_interf_lin = 0
+            oob_power = np.resize(-500, len(ue))
             if self.adjacent_channel:
-                if self.parameters.imt.adjacent_interf_model == "SPECTRAL_MASK":
-                    # Out-of-band power in the adjacent channel.
-                    oob_power = self.system.spectral_mask.power_calc(self.parameters.imt.frequency,
-                                                                     self.parameters.imt.bandwidth)
-                    oob_interf_lin = np.power(10, 0.1 * oob_power) / \
-                        np.power(10, 0.1 * self.parameters.imt.ue.adjacent_ch_selectivity)
-                elif self.parameters.imt.adjacent_interf_model == "ACIR":
-                    acir = -10 * np.log10(10**(-self.param_system.adjacent_ch_leak_ratio / 10) +
-                                          10**(-self.parameters.imt.ue.adjacent_ch_selectivity / 10))
-                    oob_power = self.param_system.tx_power_density + \
-                        10 * np.log10(self.param_system.bandwidth * 1e6) -  \
-                        acir
-                    oob_interf_lin = 10**(oob_power / 10)
+                # adj_weights is the factor of how much of the rx bw doesn't overlap with tx bw
+                adj_weights = 1. - weights
+
+                # emissions outside of tx bandwidth and inside of rx bw
+                # due to oob emissions on tx side
+                tx_oob = np.resize(-500, len(ue))
+
+                # emissions outside of rx bw and inside of tx bw
+                # due to non ideal filtering on rx side
+                # will be the same for all UE's, only considering
+                rx_oob = np.resize(-500, len(ue))
+
+                # TODO: M.2101 states that:
+                # "The ACIR value should be calculated based on per UE allocated number of resource blocks"
+
+                # should we actually implement that for ACS since the receiving filter is fixed?
+
+                # or maybe ignore ACS altogether (ACS = inf)? If we consider only allocated RB, it makes
+                # no sense to use ACS.
+                # At the same time, ignoring ACS doesn't seem correct since the interference
+                # could DECREASE when it would make sense for it to increase.
+                # e.g. adjacent systems -> slightly co-channel with ACS = inf
+                # should interfer ^        less than this ^
+
+                # Unless we never use ACS..?
+
+                if self.parameters.imt.adjacent_ch_reception == "ACS":
+                    if self.overlapping_bandwidth > 0:
+                        if not hasattr(self, "ALREADY_WARNED_ABOUT_ACS_WHEN_OVERLAPPING_BAND"):
+                            print(
+                                "[WARNING]: You're trying to use ACS on a partially overlapping band"
+                                "with UEs. Verify the code implements the behavior you expect"
+                            )
+                            self.ALREADY_WARNED_ABOUT_ACS_WHEN_OVERLAPPING_BAND = True
+                    # only apply ACS over non overlapping bw
+                    p_tx = self.param_system.tx_power_density \
+                            + 10 * np.log10(
+                                (self.param_system.bandwidth - self.overlapping_bandwidth) * 1e6
+                            )
+
+                    rx_oob[::] = p_tx - self.parameters.imt.ue.adjacent_ch_selectivity
+                elif self.parameters.imt.adjacent_ch_reception ==  "OFF":
+                    pass
+                else:
+                    raise ValueError(
+                        f"No implementation for parameters.imt.adjacent_ch_reception == {self.parameters.imt.adjacent_ch_reception}"
+                    )
+
+                # for tx oob we accept ACLR and spectral mask
+                if self.param_system.adjacent_ch_emissions == "SPECTRAL_MASK":
+                    ue_bws = self.ue.bandwidth[ue]
+                    center_freqs = self.ue.center_freq[ue]
+
+                    for i, center_freq, bw in zip(range(len(center_freqs)), center_freqs, ue_bws):
+                        # calculate tx emissions in UE in use bandwidth only
+                        tx_oob[i] = self.system.spectral_mask.power_calc(
+                            center_freq,
+                            bw
+                        )
+                elif self.param_system.adjacent_ch_emissions == "ACLR":
+                    if self.param_system.bandwidth > self.overlapping_bandwidth:
+                        tx_oob[::] = self.param_system.tx_power_density + \
+                            10 * np.log10(self.param_system.bandwidth * 1e6) -  \
+                            self.param_system.adjacent_ch_leak_ratio
+                elif self.param_system.adjacent_ch_emissions ==  "OFF":
+                    pass
+                else:
+                    raise ValueError(
+                        f"No implementation for param_system.adjacent_ch_emissions == {self.param_system.adjacent_ch_emissions}"
+                    )
+
                 # Out of band power
-                oob_power = 10 * np.log10(oob_interf_lin) - self.coupling_loss_imt_system[ue, :][:, active_sys]
+                # sum linearly power leaked into band and power received in the adjacent band
+
+                oob_power = 10 * np.log10(
+                    10 ** (0.1 * tx_oob) + 10 ** (0.1 * rx_oob)
+                )
+                # repeat ue received power for each coupling loss
+                oob_power = np.tile(
+                    np.reshape(
+                        oob_power,
+                        (-1, 1)
+                    ),
+                    (1, len(active_sys))
+                )
+                # could use different coupling loss if
+                # different antenna pattern is to be considered on adj channel
+                oob_power -= self.coupling_loss_imt_system[ue, :][:, active_sys]
 
             # Total external interference into the UE in dBm
             ue_ext_int = 10 * np.log10(np.power(10, 0.1 * in_band_interf_power) + np.power(10, 0.1 * oob_power))

--- a/sharc/simulation_uplink.py
+++ b/sharc/simulation_uplink.py
@@ -237,9 +237,10 @@ class SimulationUplink(Simulation):
                 if self.overlapping_bandwidth:
                     acs = 0
                     weights = self.calculate_bw_weights(
-                        self.parameters.imt.bandwidth,
+                        self.ue.bandwidth,
+                        self.ue.center_freq,
                         self.param_system.bandwidth,
-                        self.parameters.imt.ue.k,
+                        self.param_system.frequency,
                     )
                 else:
                     acs = self.param_system.adjacent_ch_selectivity

--- a/sharc/station_factory.py
+++ b/sharc/station_factory.py
@@ -56,6 +56,7 @@ from sharc.topology.topology import Topology
 from sharc.topology.topology_ntn import TopologyNTN
 from sharc.topology.topology_macrocell import TopologyMacrocell
 from sharc.mask.spectral_mask_3gpp import SpectralMask3Gpp
+from sharc.mask.spectral_mask_mss import SpectralMaskMSS
 from sharc.satellite.ngso.orbit_model import OrbitModel
 from sharc.satellite.utils.sat_utils import calc_elevation, lla2ecef
 from sharc.support.sharc_geom import cartesian_to_polar, polar_to_cartesian, rotate_angles_based_on_new_nadir, GeometryConverter
@@ -1192,9 +1193,13 @@ class StationFactory(object):
                                                     param_mss.bandwidth,
                                                     param_mss.spurious_emissions,
                                                     scenario="OUTDOOR")
+        elif params.spectral_mask == "MSS":
+            mss_d2d.spectral_mask = SpectralMaskMSS(params.frequency,
+                                                     params.bandwidth,
+                                                     params.spurious_emissions)
         else:
             raise ValueError(f"Invalid or not implemented spectral mask - {param_mss.spectral_mask}")
-        mss_ss.spectral_mask.set_mask(param_mss.tx_power_density + 10 * np.log10(param_mss.bandwidth * 10e6))
+        mss_ss.spectral_mask.set_mask(param_mss.tx_power_density + 10 * np.log10(param_mss.bandwidth * 1e6))
 
         return mss_ss
 
@@ -1248,9 +1253,13 @@ class StationFactory(object):
                                                      params.bandwidth,
                                                      params.spurious_emissions,
                                                      scenario="OUTDOOR")
+        elif params.spectral_mask == "MSS":
+            mss_d2d.spectral_mask = SpectralMaskMSS(params.frequency,
+                                                     params.bandwidth,
+                                                     params.spurious_emissions)
         else:
             raise ValueError(f"Invalid or not implemented spectral mask - {params.spectral_mask}")
-        mss_d2d.spectral_mask.set_mask(params.tx_power_density + 10 * np.log10(params.bandwidth * 10e6))
+        mss_d2d.spectral_mask.set_mask(params.tx_power_density + 10 * np.log10(params.bandwidth * 1e6))
 
         # Initialize arrays to store satellite positions, angles and distance from center of earth
         all_positions = {"R": [], "lat": [], "lon": [], "sx": [], "sy": [], "sz": []}

--- a/tests/test_spectral_mask_mss.py
+++ b/tests/test_spectral_mask_mss.py
@@ -13,62 +13,16 @@ from sharc.mask.spectral_mask_mss import SpectralMaskMSS
 
 
 class SpectalMaskMSSTest(unittest.TestCase):
-
-    # def setUp(self):
-    #     # Initialize variables for 40 GHz
-    #     p_tx = 25.1
-    #     freq = 43000
-    #     band = 200
-    #     spurious = -13
-
-    #     # Create mask for 40 GHz
-    #     self.mask_bs_40GHz = SpectralMaskMSS(freq, band, spurious)
-    #     self.mask_bs_40GHz.set_mask(p_tx)
-
-    #     # Initialize variables for 40 GHz
-    #     p_tx = 28.1
-    #     freq = 24350
-    #     band = 200
-
-    #     # Create mask for BS at 26 GHz
-    #     self.mask_bs_26GHz = SpectralMaskMSS(freq, band, spurious)
-    #     self.mask_bs_26GHz.set_mask(p_tx)
-
-    #     # Create mask for UE at 26 GHz
-    #     self.mask_ue_26GHz = SpectralMaskMSS(freq, band, spurious)
-    #     self.mask_ue_26GHz.set_mask(p_tx)
-
-    #     # Initialize variables for 9GHz -13dBm/MHz
-    #     p_tx = 28.1
-    #     freq = 9000
-    #     band = 200
-
-    #     # Create mask for BS at 9 GHz
-    #     self.mask_bs_9GHz = SpectralMaskMSS(freq, band, -13)
-    #     self.mask_bs_9GHz.set_mask(p_tx)
-
-    #     # Initialize variables for 9GHz -30dBm/MHz
-    #     p_tx = 28.1
-    #     freq = 9000
-    #     band = 200
-
-    #     # Create mask for BS at 9 GHz and spurious emission at -30dBm/MHz
-    #     self.mask_bs_9GHz_30_spurious = SpectralMaskMSS(
-    #         freq, band, -30)
-    #     self.mask_bs_9GHz_30_spurious.set_mask(p_tx)
-
     def test_power_calc(self):
-        #######################################################################
-        # Testing mask for 40 GHz
-        #######################################################################
-
         # Test 1
         p_tx_density = -30 # dBW / Hz
         freq = 2190
         band = 1
         p_tx = p_tx_density + 10 * np.log10(band * 1e6)
+
         # reference bw is 4khz below 15GHz center freq
         p_tx_over_4khz = p_tx_density + 10 * np.log10(4e3)
+
         # dBm/MHz
         spurious_emissions = -30
 

--- a/tests/test_spectral_mask_mss.py
+++ b/tests/test_spectral_mask_mss.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Tue Dec  5 11:56:10 2017
+
+@author: Calil
+"""
+
+import unittest
+import numpy as np
+import numpy.testing as npt
+
+from sharc.mask.spectral_mask_mss import SpectralMaskMSS
+
+
+class SpectalMaskMSSTest(unittest.TestCase):
+
+    # def setUp(self):
+    #     # Initialize variables for 40 GHz
+    #     p_tx = 25.1
+    #     freq = 43000
+    #     band = 200
+    #     spurious = -13
+
+    #     # Create mask for 40 GHz
+    #     self.mask_bs_40GHz = SpectralMaskMSS(freq, band, spurious)
+    #     self.mask_bs_40GHz.set_mask(p_tx)
+
+    #     # Initialize variables for 40 GHz
+    #     p_tx = 28.1
+    #     freq = 24350
+    #     band = 200
+
+    #     # Create mask for BS at 26 GHz
+    #     self.mask_bs_26GHz = SpectralMaskMSS(freq, band, spurious)
+    #     self.mask_bs_26GHz.set_mask(p_tx)
+
+    #     # Create mask for UE at 26 GHz
+    #     self.mask_ue_26GHz = SpectralMaskMSS(freq, band, spurious)
+    #     self.mask_ue_26GHz.set_mask(p_tx)
+
+    #     # Initialize variables for 9GHz -13dBm/MHz
+    #     p_tx = 28.1
+    #     freq = 9000
+    #     band = 200
+
+    #     # Create mask for BS at 9 GHz
+    #     self.mask_bs_9GHz = SpectralMaskMSS(freq, band, -13)
+    #     self.mask_bs_9GHz.set_mask(p_tx)
+
+    #     # Initialize variables for 9GHz -30dBm/MHz
+    #     p_tx = 28.1
+    #     freq = 9000
+    #     band = 200
+
+    #     # Create mask for BS at 9 GHz and spurious emission at -30dBm/MHz
+    #     self.mask_bs_9GHz_30_spurious = SpectralMaskMSS(
+    #         freq, band, -30)
+    #     self.mask_bs_9GHz_30_spurious.set_mask(p_tx)
+
+    def test_power_calc(self):
+        #######################################################################
+        # Testing mask for 40 GHz
+        #######################################################################
+
+        # Test 1
+        p_tx_density = -30 # dBW / Hz
+        freq = 2190
+        band = 1
+        p_tx = p_tx_density + 10 * np.log10(band * 1e6)
+        # reference bw is 4khz below 15GHz center freq
+        p_tx_over_4khz = p_tx_density + 10 * np.log10(4e3)
+        # dBm/MHz
+        spurious_emissions = -30
+
+        mask = SpectralMaskMSS(
+            freq, band, spurious_emissions
+        )
+        mask.set_mask(p_tx)
+
+        N = len(mask.delta_f_lim)
+        # N = 2
+
+        should_eq = np.zeros(2 * N)
+        eq = np.zeros(2 * N)
+        spurious_start = 2 * band
+        for i in range(N):
+            f_offset = band / 2 + i * 4e-3
+
+            F = (f_offset - band/2) / band * 100
+
+            should_eq[2*i] = p_tx_over_4khz - 40 * np.log10(F/50 + 1) + 30
+            eq[2*i] = mask.power_calc(freq + f_offset + 0.5 * 4e-3, 4e-3)
+
+            should_eq[2*i + 1] = should_eq[2*i]
+            eq[2*i + 1] = mask.power_calc(freq - f_offset - 0.5 * 4e-3, 4e-3)
+
+        # substitute last should eq with spurious emissions instead of formula
+        should_eq[-1] = spurious_emissions + 10 * np.log10(4e-3)
+        should_eq[-2] = spurious_emissions + 10 * np.log10(4e-3)
+
+        npt.assert_almost_equal(should_eq, eq)
+
+        npt.assert_equal(
+            -np.inf,
+            mask.power_calc(
+                freq, band
+            )
+        )
+
+        fll = mask.power_calc(freq + 1.5 * band,  2*band)
+
+        # this test only passes when considering 0 decimal places...
+        # there is a noticeable difference in result from continous integration (by hand)
+        # and the discrete integration implemented on SHARC. Could be mitigated
+        # by implementing the mask differently
+        self.assertAlmostEqual(fll, 10 * np.log10(165.33 * 1000), places=0)
+
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
Update downlink simulation so that:
- ACS is only applied on emissions outside the full system bandwidth, since it should equal to the receive filter bandwidth;
- Spectral Mask of other system, when interfering on UE's, is applied only on the used UE RB's;
- ACLR is only applied considering the bandwidth that is not co-channel;

Added spectral mask MSS according to document REC ITU-R SM.1541, since it is said that it should be used on document R23-WP4C-C-0204!N04, our reference for MSS D2D studies.

System A suggests this mask to be used. Some other systems suggest an EIRP formula instead to be applied for ACLR1, ACLR2 and ACLR3. It would be a much bigger modification to implement an EIRP option for the interferer in SHARC, and we're not simulating the system that suggests it, so it hasn't been implemented.