### PR TITLE
update: added beamsteering limit to IMT

### DIFF
--- a/sharc/input/parameters.yaml
+++ b/sharc/input/parameters.yaml
@@ -203,7 +203,13 @@ imt:
             # If normalization of M2101 should be applied for BS
             normalization: FALSE
             ###########################################################################
-            # If normalization of M2101 should be applied for UE
+            # Base station horizontal beamsteering range. [deg]
+            # The range considers the BS azimuth as 0deg
+            horizontal_beamsteering_range: !!python/tuple [-60., 60.]
+            ###########################################################################
+            # Base station horizontal beamsteering range. [deg]
+            # The range considers the horizon as 90deg, 0 as zenith
+            vertical_beamsteering_range: !!python/tuple [90., 100.]
             ###########################################################################
             # File to be used in the BS beamforming normalization
             # Normalization files can be generated with the

--- a/sharc/parameters/imt/parameters_antenna_imt.py
+++ b/sharc/parameters/imt/parameters_antenna_imt.py
@@ -53,6 +53,12 @@ class ParametersAntennaImt(ParametersBase):
     # Minimum array gain for the beamforming antenna [dBi].
     minimum_array_gain: float = -200.0
 
+    # beamforming angle limitation [deg].
+    # PS: it isn't implemented for UEs
+    # and current implementation doesn't make sense for UEs
+    horizontal_beamsteering_range: tuple[float, float] = (-60.,60.)
+    vertical_beamsteering_range: tuple[float, float] = (90.,100.)
+
     # Mechanical downtilt [degrees].
     # PS: downtilt doesn't make sense on UE's
     downtilt: float = 6.0

--- a/sharc/parameters/imt/parameters_antenna_imt.py
+++ b/sharc/parameters/imt/parameters_antenna_imt.py
@@ -56,8 +56,8 @@ class ParametersAntennaImt(ParametersBase):
     # beamforming angle limitation [deg].
     # PS: it isn't implemented for UEs
     # and current implementation doesn't make sense for UEs
-    horizontal_beamsteering_range: tuple[float, float] = (-60.,60.)
-    vertical_beamsteering_range: tuple[float, float] = (90.,100.)
+    horizontal_beamsteering_range: tuple[float, float] = (-60., 60.)
+    vertical_beamsteering_range: tuple[float, float] = (90., 100.)
 
     # Mechanical downtilt [degrees].
     # PS: downtilt doesn't make sense on UE's

--- a/sharc/parameters/imt/parameters_antenna_imt.py
+++ b/sharc/parameters/imt/parameters_antenna_imt.py
@@ -56,8 +56,8 @@ class ParametersAntennaImt(ParametersBase):
     # beamforming angle limitation [deg].
     # PS: it isn't implemented for UEs
     # and current implementation doesn't make sense for UEs
-    horizontal_beamsteering_range: tuple[float, float] = (-180., 180.)
-    vertical_beamsteering_range: tuple[float, float] = (0., 180.)
+    horizontal_beamsteering_range: tuple[float | int, float | int] = (-180., 180.)
+    vertical_beamsteering_range: tuple[float | int, float | int] = (0., 180.)
 
     # Mechanical downtilt [degrees].
     # PS: downtilt doesn't make sense on UE's
@@ -115,6 +115,62 @@ class ParametersAntennaImt(ParametersBase):
         if self.element_pattern.upper() not in ["M2101", "F1336", "FIXED"]:
             raise ValueError(
                 f"Invalid element_pattern value {self.element_pattern}",
+            )
+        if isinstance(self.horizontal_beamsteering_range, list):
+            self.horizontal_beamsteering_range = tuple(self.horizontal_beamsteering_range)
+
+        if not isinstance(self.horizontal_beamsteering_range, tuple):
+            raise ValueError(
+                f"Invalid {ctx}.horizontal_beamsteering_range={self.horizontal_beamsteering_range}\n"
+                "It needs to be a tuple"
+            )
+        if len(self.horizontal_beamsteering_range) != 2\
+            or not all(map(
+                lambda x: isinstance(x, float) or isinstance(x, int), self.horizontal_beamsteering_range
+            )):
+            raise ValueError(
+                f"Invalid {ctx}.horizontal_beamsteering_range={self.horizontal_beamsteering_range}\n"
+                "It needs to contain two numbers delimiting the range of beamsteering in degrees"
+            )
+        if self.horizontal_beamsteering_range[0] > self.horizontal_beamsteering_range[1]:
+            raise ValueError(
+                f"Invalid {ctx}.horizontal_beamsteering_range={self.horizontal_beamsteering_range}\n"
+                "The second value must be bigger than the first"
+            )
+        if not all(map(
+                lambda x: x >= -180. and x <= 180., self.horizontal_beamsteering_range
+            )):
+            raise ValueError(
+                f"Invalid {ctx}.horizontal_beamsteering_range={self.horizontal_beamsteering_range}\n"
+                "Horizontal beamsteering limit angles must be in the range [-180, 180]"
+            )
+
+        if isinstance(self.vertical_beamsteering_range, list):
+            self.vertical_beamsteering_range = tuple(self.vertical_beamsteering_range)
+        if not isinstance(self.vertical_beamsteering_range, tuple):
+            raise ValueError(
+                f"Invalid {ctx}.vertical_beamsteering_range={self.vertical_beamsteering_range}\n"
+                "It needs to be a tuple"
+            )
+        if len(self.vertical_beamsteering_range) != 2\
+            or not all(map(
+                lambda x: isinstance(x, float) or isinstance(x, int), self.vertical_beamsteering_range
+            )):
+            raise ValueError(
+                f"Invalid {ctx}.vertical_beamsteering_range={self.vertical_beamsteering_range}\n"
+                "It needs to contain two numbers delimiting the range of beamsteering in degrees"
+            )
+        if self.vertical_beamsteering_range[0] > self.vertical_beamsteering_range[1]:
+            raise ValueError(
+                f"Invalid {ctx}.vertical_beamsteering_range={self.vertical_beamsteering_range}\n"
+                "The second value must be bigger than the first"
+            )
+        if not all(map(
+                lambda x: x >= 0. and x <= 180., self.vertical_beamsteering_range
+            )):
+            raise ValueError(
+                f"Invalid {ctx}.vertical_beamsteering_range={self.vertical_beamsteering_range}\n"
+                "vertical beamsteering limit angles must be in the range [0, 180]"
             )
 
     def get_antenna_parameters(self) -> AntennaPar:

--- a/sharc/parameters/imt/parameters_antenna_imt.py
+++ b/sharc/parameters/imt/parameters_antenna_imt.py
@@ -56,8 +56,8 @@ class ParametersAntennaImt(ParametersBase):
     # beamforming angle limitation [deg].
     # PS: it isn't implemented for UEs
     # and current implementation doesn't make sense for UEs
-    horizontal_beamsteering_range: tuple[float, float] = (-60., 60.)
-    vertical_beamsteering_range: tuple[float, float] = (90., 100.)
+    horizontal_beamsteering_range: tuple[float, float] = (-180., 180.)
+    vertical_beamsteering_range: tuple[float, float] = (0., 180.)
 
     # Mechanical downtilt [degrees].
     # PS: downtilt doesn't make sense on UE's

--- a/sharc/parameters/imt/parameters_imt.py
+++ b/sharc/parameters/imt/parameters_imt.py
@@ -68,7 +68,13 @@ class ParametersImt(ParametersBase):
         noise_figure: float = 10.0
         ohmic_loss: float = 3.0
         body_loss: float = 4.0
-        antenna: ParametersAntennaImt = field(default_factory=lambda: ParametersAntennaImt(downtilt=0.0))
+        antenna: ParametersAntennaImt = field(
+            default_factory=lambda: ParametersAntennaImt(
+                                        downtilt=0.0,
+                                        horizontal_beamsteering_range=(-180.,180.),
+                                        vertical_beamsteering_range=(0.,180.)
+                                    )
+        )
 
     ue: ParametersUE = field(default_factory=ParametersUE)
 

--- a/sharc/parameters/imt/parameters_imt.py
+++ b/sharc/parameters/imt/parameters_imt.py
@@ -68,13 +68,7 @@ class ParametersImt(ParametersBase):
         noise_figure: float = 10.0
         ohmic_loss: float = 3.0
         body_loss: float = 4.0
-        antenna: ParametersAntennaImt = field(
-            default_factory=lambda: ParametersAntennaImt(
-                                        downtilt=0.0,
-                                        horizontal_beamsteering_range=(-180., 180.),
-                                        vertical_beamsteering_range=(0., 180.)
-                                    )
-        )
+        antenna: ParametersAntennaImt = field(default_factory=lambda: ParametersAntennaImt(downtilt=0.0,))
 
     ue: ParametersUE = field(default_factory=ParametersUE)
 

--- a/sharc/parameters/imt/parameters_imt.py
+++ b/sharc/parameters/imt/parameters_imt.py
@@ -71,8 +71,8 @@ class ParametersImt(ParametersBase):
         antenna: ParametersAntennaImt = field(
             default_factory=lambda: ParametersAntennaImt(
                                         downtilt=0.0,
-                                        horizontal_beamsteering_range=(-180.,180.),
-                                        vertical_beamsteering_range=(0.,180.)
+                                        horizontal_beamsteering_range=(-180., 180.),
+                                        vertical_beamsteering_range=(0., 180.)
                                     )
         )
 

--- a/sharc/parameters/imt/parameters_imt.py
+++ b/sharc/parameters/imt/parameters_imt.py
@@ -70,6 +70,14 @@ class ParametersImt(ParametersBase):
         body_loss: float = 4.0
         antenna: ParametersAntennaImt = field(default_factory=lambda: ParametersAntennaImt(downtilt=0.0,))
 
+        def validate(self, ctx: str):
+            if self.antenna.horizontal_beamsteering_range != (-180., 180.)\
+                    or self.antenna.vertical_beamsteering_range != (0., 180.):
+                raise NotImplementedError(
+                    "UE antenna beamsteering limit has not been implemented. Default values of\n"
+                    "horizontal = (-180., 180.), vertical = (0., 180.) should not be changed"
+                )
+
     ue: ParametersUE = field(default_factory=ParametersUE)
 
     @dataclass

--- a/sharc/simulation.py
+++ b/sharc/simulation.py
@@ -409,10 +409,26 @@ class Simulation(ABC, Observable):
                 self.ue.active[self.link[bs]] = np.ones(K, dtype=bool)
                 for ue in self.link[bs]:
                     # add beam to BS antennas
-                    self.bs.antenna[bs].add_beam(
+
+                    # limit beamforming angle
+                    bs_beam_phi = np.clip(
                         self.bs_to_ue_phi[bs, ue],
-                        self.bs_to_ue_theta[bs, ue],
+                        *(self.parameters.imt.bs.antenna.horizontal_beamsteering_range + self.bs.azimuth[bs])
                     )
+
+                    bs_beam_theta = np.clip(
+                        self.bs_to_ue_theta[bs, ue],
+                        *self.parameters.imt.bs.antenna.vertical_beamsteering_range
+                    )
+
+                    self.bs.antenna[bs].add_beam(
+                        bs_beam_phi,
+                        bs_beam_theta,
+                    )
+
+                    # TODO?: limit beamforming on UE as well
+                    # would make sense, but we don't have any parameters explicitly setting it
+
                     # add beam to UE antennas
                     self.ue.antenna[ue].add_beam(
                         self.bs_to_ue_phi[bs, ue] - 180,

--- a/tests/parameters/parameters_for_testing.yaml
+++ b/tests/parameters/parameters_for_testing.yaml
@@ -203,7 +203,13 @@ imt:
             # If normalization of M2101 should be applied for BS
             normalization  : FALSE
             ###########################################################################
-            # If normalization of M2101 should be applied for UE
+            # Base station horizontal beamsteering range. [deg]
+            # The range considers the BS azimuth as 0deg
+            horizontal_beamsteering_range: !!python/tuple [-10.1, 11.2]
+            ###########################################################################
+            # Base station horizontal beamsteering range. [deg]
+            # The range considers the horizon as 90deg, 0 as zenith
+            vertical_beamsteering_range: !!python/tuple [0., 180.]
             ###########################################################################
             # File to be used in the BS beamforming normalization
             # Normalization files can be generated with the

--- a/tests/parameters/test_parameters.py
+++ b/tests/parameters/test_parameters.py
@@ -29,6 +29,8 @@ class ParametersTest(unittest.TestCase):
         self.assertEqual(self.parameters.imt.spurious_emissions, -13.1)
         self.assertEqual(self.parameters.imt.guard_band_ratio, 0.14)
 
+        self.assertEqual(self.parameters.imt.bs.antenna.horizontal_beamsteering_range, (-10.1, 11.2))
+        self.assertEqual(self.parameters.imt.bs.antenna.vertical_beamsteering_range, (0., 180.))
         self.assertEqual(self.parameters.imt.bs.load_probability, 0.2)
         self.assertEqual(self.parameters.imt.bs.conducted_power, 11.1)
         self.assertEqual(self.parameters.imt.bs.height, 6.1)
@@ -37,6 +39,8 @@ class ParametersTest(unittest.TestCase):
         self.assertEqual(self.parameters.imt.uplink.attenuation_factor, 0.4)
         self.assertEqual(self.parameters.imt.uplink.sinr_min, -10.0)
         self.assertEqual(self.parameters.imt.uplink.sinr_max, 22.0)
+        self.assertEqual(self.parameters.imt.ue.antenna.horizontal_beamsteering_range, (-180., 180.))
+        self.assertEqual(self.parameters.imt.ue.antenna.vertical_beamsteering_range, (0., 180.))
         self.assertEqual(self.parameters.imt.ue.k, 3)
         self.assertEqual(self.parameters.imt.ue.k_m, 1)
         self.assertEqual(self.parameters.imt.ue.indoor_percent, 5.0)

--- a/tests/test_simulation_indoor.py
+++ b/tests/test_simulation_indoor.py
@@ -41,9 +41,6 @@ class SimulationIndoorTest(unittest.TestCase):
         self.param.imt.guard_band_ratio = 0.1
         self.param.imt.bs.load_probability = 1
 
-        self.param.imt.bs.antenna.horizontal_beamsteering_range = (-180., 180.)
-        self.param.imt.bs.antenna.vertical_beamsteering_range = (0., 180.)
-
         self.param.imt.bs.conducted_power = 2
         self.param.imt.bs.height = 3
         self.param.imt.bs.noise_figure = 12

--- a/tests/test_simulation_indoor.py
+++ b/tests/test_simulation_indoor.py
@@ -41,6 +41,9 @@ class SimulationIndoorTest(unittest.TestCase):
         self.param.imt.guard_band_ratio = 0.1
         self.param.imt.bs.load_probability = 1
 
+        self.param.imt.bs.antenna.horizontal_beamsteering_range = (-180., 180.)
+        self.param.imt.bs.antenna.vertical_beamsteering_range = (0., 180.)
+
         self.param.imt.bs.conducted_power = 2
         self.param.imt.bs.height = 3
         self.param.imt.bs.noise_figure = 12


### PR DESCRIPTION
Adds parameter to limit beamsteering angle for IMT BS. Default range is full range of motion, to not change current campaigns results

Solves issue #128 