### PR TITLE
Change in Clutter Loss function and Addition possible P452 as propagation for FS

### DIFF
--- a/sharc/parameters/parameters_fs.py
+++ b/sharc/parameters/parameters_fs.py
@@ -116,7 +116,7 @@ class ParametersFs(ParametersBase):
             )
 
         # Sanity check for channel model
-        if self.channel_model not in ["FSPL", "TerrestrialSimple","P452"]:
+        if self.channel_model not in ["FSPL", "TerrestrialSimple", "P452"]:
             raise ValueError(
                 "Invalid channel_model, must be either 'FSPL', 'TerrestrialSimple', or 'P452'",
             )

--- a/sharc/parameters/parameters_fs.py
+++ b/sharc/parameters/parameters_fs.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from sharc.parameters.parameters_base import ParametersBase
+from sharc.parameters.parameters_p452 import ParametersP452
 
 
 @dataclass
@@ -49,8 +50,38 @@ class ParametersFs(ParametersBase):
     diameter: float = 0.3
 
     # Channel model, possible values are "FSPL" (free-space path loss),
-    # "TerrestrialSimple" (FSPL + clutter loss)
+    # "TerrestrialSimple" (FSPL + clutter loss),
+    # P452
     channel_model: str = "FSPL"
+
+    # P452 parameters
+    param_p452 = ParametersP452()
+    # Total air pressure in hPa
+    atmospheric_pressure: float = 935.0
+    # Temperature in Kelvin
+    air_temperature: float = 300.0
+    # Sea-level surface refractivity (use the map)
+    N0: float = 352.58
+    # Average radio-refractive (use the map)
+    delta_N: float = 43.127
+    # Percentage p. Float (0 to 100) or RANDOM
+    percentage_p: str = "0.2"
+    # Distance over land from the transmit and receive antennas to the coast (km)
+    Dct: float = 70.0
+    # Distance over land from the transmit and receive antennas to the coast (km)
+    Dcr: float = 70.0
+    # Effective height of interfering antenna (m)
+    Hte: float = 20.0
+    # Effective height of interfered-with antenna (m)
+    Hre: float = 3.0
+    # Latitude of transmitter
+    tx_lat: float = -23.55028
+    # Latitude of receiver
+    rx_lat: float = -23.17889
+    # Antenna polarization
+    polarization: str = "horizontal"
+    # Determine whether clutter loss following ITU-R P.2108 is added (TRUE/FALSE)
+    clutter_loss: bool = True
 
     def load_parameters_from_file(self, config_file: str):
         """
@@ -85,7 +116,9 @@ class ParametersFs(ParametersBase):
             )
 
         # Sanity check for channel model
-        if self.channel_model not in ["FSPL", "TerrestrialSimple"]:
+        if self.channel_model not in ["FSPL", "TerrestrialSimple","P452"]:
             raise ValueError(
-                "Invalid channel_model, must be either 'FSPL' or 'TerrestrialSimple'",
+                "Invalid channel_model, must be either 'FSPL', 'TerrestrialSimple', or 'P452'",
             )
+        if self.channel_model == "P452":
+            self.param_p452.load_from_paramters(self)

--- a/sharc/propagation/propagation_clutter_loss.py
+++ b/sharc/propagation/propagation_clutter_loss.py
@@ -92,7 +92,7 @@ class PropagationClutterLoss(Propagation):
             loss = self.get_terrestrial_clutter_loss(f, d, p1, True) + self.get_terrestrial_clutter_loss(f, d, p2, False)
         else:
             theta = kwargs["elevation"]
-            loss = self.get_spacial_clutter_loss(f, theta, p)
+            loss = self.get_spacial_clutter_loss(f, theta, p1)
         return loss
 
     def get_spacial_clutter_loss(

--- a/sharc/propagation/propagation_clutter_loss.py
+++ b/sharc/propagation/propagation_clutter_loss.py
@@ -85,7 +85,8 @@ class PropagationClutterLoss(Propagation):
             p1 = self.random_number_gen.random_sample(d.shape)
             p2 = self.random_number_gen.random_sample(d.shape)
         else:
-            p = loc_per * np.ones(d.shape)
+            p1 = loc_per * np.ones(d.shape)
+            p2 = loc_per * np.ones(d.shape)
 
         if type is StationType.IMT_BS or type is StationType.IMT_UE or type is StationType.FSS_ES:
             loss = self.get_terrestrial_clutter_loss(f, d, p1, True) + self.get_terrestrial_clutter_loss(f, d, p2, False)

--- a/sharc/propagation/propagation_clutter_loss.py
+++ b/sharc/propagation/propagation_clutter_loss.py
@@ -219,7 +219,6 @@ class PropagationClutterLoss(Propagation):
             id_max = np.where(loss >= loss_2km)[0]
             loss[id_max] = loss_2km[id_max]
 
-        loss *= 2
         loss = loss.reshape(distance.shape)
 
         return loss

--- a/sharc/propagation/propagation_clutter_loss.py
+++ b/sharc/propagation/propagation_clutter_loss.py
@@ -82,12 +82,13 @@ class PropagationClutterLoss(Propagation):
             f = f * np.ones(d.shape)
 
         if isinstance(loc_per, str) and loc_per.upper() == "RANDOM":
-            p = self.random_number_gen.random_sample(d.shape)
+            p1 = self.random_number_gen.random_sample(d.shape)
+            p2 = self.random_number_gen.random_sample(d.shape)
         else:
             p = loc_per * np.ones(d.shape)
 
         if type is StationType.IMT_BS or type is StationType.IMT_UE or type is StationType.FSS_ES:
-            loss = self.get_terrestrial_clutter_loss(f, d, p)
+            loss = self.get_terrestrial_clutter_loss(f, d, p1, True) + self.get_terrestrial_clutter_loss(f, d, p2, False)
         else:
             theta = kwargs["elevation"]
             loss = self.get_spacial_clutter_loss(f, theta, p)


### PR DESCRIPTION
1. Clutter loss - I have changed clutter_loss to fix the one_end and both_ends.
- I added another random variable, "p2," when the distance>1km, and we need to apply for both ends.
- Changed the loss calculation for terrestrial clutter:  loss = self.get_terrestrial_clutter_loss(f, d, p1, True) + self.get_terrestrial_clutter_loss(f, d, p2, False). The first term is related to distances>1km (when the True flag), and the second sum is added for distances>250 (flag: False). In this sense, the clutter is added once for 250<distance<1km, and twice for distance>1km.

2. I changed the parameters_fs so that P452 can be placed as a propagation model from IMT to FS. I defined default P452 parameters and added the model. 
 