### PR TITLE
feat: ue distribution_distance: SQRT(UNIFORM)

### DIFF
--- a/sharc/input/parameters.yaml
+++ b/sharc/input/parameters.yaml
@@ -311,7 +311,7 @@ imt:
         ###########################################################################
         # Regarding the distribution of active UE's over the cell area, this
         # parameter models the distance between UE's and BS.
-        # Possible values: RAYLEIGH, UNIFORM
+        # Possible values: RAYLEIGH, UNIFORM, SQRT(UNIFORM)
         distribution_distance: UNIFORM
         ###########################################################################
         # Regarding the distribution of active UE's over the cell area, this

--- a/sharc/station_factory.py
+++ b/sharc/station_factory.py
@@ -257,6 +257,9 @@ class StationFactory(object):
             elif param.ue.distribution_distance.upper() == "UNIFORM":
                 radius = topology.cell_radius * \
                     random_number_gen.random_sample(num_ue)
+            elif param.ue.distribution_distance.upper() == "SQRT(UNIFORM)":
+                radius = topology.cell_radius * \
+                    np.sqrt(random_number_gen.random_sample(num_ue))
             else:
                 sys.stderr.write(
                     "ERROR\nInvalid UE distance distribution: " + param.ue.distribution_distance,


### PR DESCRIPTION
Just so we can make a uniform distribution over the area of a hotspot BS.
Choosing uniform for angle distr and sqrt(uniform) for distance distr ends up with an uniform distribution over the bs coverage area