### PR TITLE
Update/spherical earth

### DIFF
--- a/sharc/campaigns/mss_d2d_to_imt/scripts/orbit_model_anaylisis.py
+++ b/sharc/campaigns/mss_d2d_to_imt/scripts/orbit_model_anaylisis.py
@@ -56,7 +56,9 @@ if __name__ == "__main__":
                                                           n_periods=total_periods)
     sat_altitude_km = orbit.apogee_alt_km  # altitude of the satellites in kilometers
     num_of_visible_sats_per_drop = []
-    elev_angles = calc_elevation(GROUND_STA_LAT, pos_vec['lat'], GROUND_STA_LON, pos_vec['lon'], sat_altitude_km)
+    elev_angles = calc_elevation(GROUND_STA_LAT, pos_vec['lat'], GROUND_STA_LON, pos_vec['lon'],
+                                 sat_height=sat_altitude_km * 1e3,
+                                 es_height=0)
     elevation_angles_per_drop = elev_angles[np.where(np.array(elev_angles) > MIN_ELEV_ANGLE_DEG)]
     num_of_visible_sats_per_drop = np.sum(np.array(elev_angles) > MIN_ELEV_ANGLE_DEG, axis=0)
 
@@ -68,7 +70,8 @@ if __name__ == "__main__":
     elev_angles = calc_elevation(GROUND_STA_LAT,
                                  pos_vec['lat'],
                                  GROUND_STA_LON, pos_vec['lon'],
-                                 sat_altitude_km)
+                                 sat_height=sat_altitude_km * 1e3,
+                                 es_height=0)
     elevation_angles_per_drop_rand = elev_angles[np.where(np.array(elev_angles) > MIN_ELEV_ANGLE_DEG)]
     num_of_visible_sats_per_drop_rand = np.sum(np.array(elev_angles) > MIN_ELEV_ANGLE_DEG, axis=0)
 

--- a/sharc/satellite/ngso/constants.py
+++ b/sharc/satellite/ngso/constants.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 # CONSTANTS
-EARTH_RADIUS = 6378145  # radius of the Earth, in m
+EARTH_RADIUS_M = 6378145  # radius of the Earth, in m
 EARTH_RADIUS_KM = 6378.145  # radius of the Earth, in km
 KEPLER_CONST = 398601.8  # Kepler's constant, in km^3/s^2
 EARTH_ROTATION_RATE = 2 * np.pi / (24 * 3600)  # earth's average rotation rate, in rad/s

--- a/sharc/satellite/ngso/constants.py
+++ b/sharc/satellite/ngso/constants.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 # CONSTANTS
+EARTH_RADIUS = 6378145  # radius of the Earth, in m
 EARTH_RADIUS_KM = 6378.145  # radius of the Earth, in km
 KEPLER_CONST = 398601.8  # Kepler's constant, in km^3/s^2
 EARTH_ROTATION_RATE = 2 * np.pi / (24 * 3600)  # earth's average rotation rate, in rad/s

--- a/sharc/satellite/ngso/orbit_model.py
+++ b/sharc/satellite/ngso/orbit_model.py
@@ -168,6 +168,7 @@ class OrbitModel():
         pos_vector = {
             'lat': lat,
             'lon': lon,
+            'alt': r - EARTH_RADIUS_KM,
             'sx': sx,
             'sy': sy,
             'sz': sz

--- a/sharc/satellite/scripts/plot_satellites_3d.py
+++ b/sharc/satellite/scripts/plot_satellites_3d.py
@@ -147,7 +147,9 @@ if __name__ == "__main__":
     NUM_DROPS = 1000
     rng = np.random.RandomState(seed=6)
     pos_vec = orbit.get_orbit_positions_random(rng=rng, n_samples=NUM_DROPS)
-    look_angles = calc_elevation(GROUND_STA_LAT, pos_vec['lat'], GROUND_STA_LON, pos_vec['lon'], orbit.apogee_alt_km)
+    look_angles = calc_elevation(GROUND_STA_LAT, pos_vec['lat'], GROUND_STA_LON, pos_vec['lon'],
+                                 sat_height=orbit.apogee_alt_km * 1e3,
+                                 es_height=0)
     elevation_angles_per_drop = look_angles[np.where(np.array(look_angles) > 0)]
     num_of_visible_sats_per_drop = np.sum(look_angles > MIN_ELEV_ANGLE_DEG, axis=0)
 

--- a/sharc/satellite/utils/sat_utils.py
+++ b/sharc/satellite/utils/sat_utils.py
@@ -1,16 +1,5 @@
 import numpy as np
-from sharc.parameters.constants import EARTH_RADIUS
-
-EARTH_RADIUS_KM = EARTH_RADIUS / 1000
-
-
-class WGS84Defs:
-    """Constants for the WGS84 ellipsoid model."""
-    SEMI_MAJOR_AXIS = 6378137.0  # Semi-major axis (in meters)
-    SEMI_MINOR_AXIS = 6356752.3  # Semi-major axis (in meters)
-    ECCENTRICITY = 8.1819190842622e-2  # WGS84 ellipsoid eccentricity
-    FLATTENING = 0.0033528106647474805
-    FIRST_ECCENTRICITY_SQRD = 6.69437999014e-3
+from sharc.satellite.ngso.constants import EARTH_RADIUS
 
 
 def ecef2lla(x: np.ndarray, y: np.ndarray, z: np.ndarray) -> tuple:
@@ -30,31 +19,33 @@ def ecef2lla(x: np.ndarray, y: np.ndarray, z: np.ndarray) -> tuple:
     tuple (lat, long, alt)
         lat long and altitude in WSG84 format
     """
-    # Longitude calculation
-    lon = np.arctan2(y, x)
+    x = np.atleast_1d(x)
+    y = np.atleast_1d(y)
+    z = np.atleast_1d(z)
+    xy = np.sqrt(x**2 + y**2)
 
-    # Iteratively solve for latitude and altitude
-    p = np.sqrt(np.power(x, 2) + np.power(y, 2))
-    lat = np.arctan2(z, p * (1 - WGS84Defs.ECCENTRICITY**2))  # Initial estimate for latitude
-    for _ in range(5):  # Iteratively improve the estimate
-        N = WGS84Defs.SEMI_MAJOR_AXIS / np.sqrt(1 - WGS84Defs.ECCENTRICITY**2 * np.sin(lat)**2)
-        alt = p / np.cos(lat) - N
-        lat = np.arctan2(z, p * (1 - WGS84Defs.ECCENTRICITY**2 * (N / (N + alt))))
+    lon = np.arccos(x / xy)
+    lon[y < 0] = -lon[y < 0]
 
-    # Convert latitude and longitude from radians to degrees
-    lat = np.degrees(lat)
-    lon = np.degrees(lon)
+    lat = np.arctan2(z, xy)
+
+    xyz = np.sqrt(x**2 + y**2 + z**2)
+    alt = xyz - EARTH_RADIUS
+
+    lat = np.rad2deg(lat)
+    lon = np.rad2deg(lon)
+
     return lat, lon, alt
 
 
-def lla2ecef(lat: np.ndarray, lng: np.ndarray, alt: np.ndarray) -> tuple:
+def lla2ecef(lat: np.ndarray, lon: np.ndarray, alt: np.ndarray) -> tuple:
     """Converts from geodetic WSG84 to ECEF coordinates
 
     Parameters
     ----------
     lat : np.ndarray
         latitude in degrees
-    lng : np.ndarray
+    lon : np.ndarray
         longitute in degrees
     alt : np.ndarray
         altitude in meters
@@ -64,12 +55,14 @@ def lla2ecef(lat: np.ndarray, lng: np.ndarray, alt: np.ndarray) -> tuple:
     tuple
         x, y and z coordinates
     """
-    lat = np.deg2rad(lat)
-    lng = np.deg2rad(lng)
-    n_phi = WGS84Defs.SEMI_MAJOR_AXIS / np.sqrt(1 - WGS84Defs.FIRST_ECCENTRICITY_SQRD * np.sin(lat)**2)
-    x = (n_phi + alt) * np.cos(lat) * np.cos(lng)
-    y = (n_phi + alt) * np.cos(lat) * np.sin(lng)
-    z = ((1 - WGS84Defs.FLATTENING)**2 * n_phi + alt) * np.sin(lat)
+    lat = np.atleast_1d(lat)
+    lon = np.atleast_1d(lon)
+    alt = np.atleast_1d(alt)
+
+    r = (alt + EARTH_RADIUS)
+    x = r * np.cos(np.deg2rad(lat)) * np.cos(np.deg2rad(lon))
+    y = r * np.cos(np.deg2rad(lat)) * np.sin(np.deg2rad(lon))
+    z = r * np.sin(np.deg2rad(lat))
 
     return x, y, z
 

--- a/sharc/satellite/utils/sat_utils.py
+++ b/sharc/satellite/utils/sat_utils.py
@@ -71,7 +71,10 @@ def calc_elevation(Le: np.ndarray,
                    Ls: np.ndarray,
                    le: np.ndarray,
                    ls: np.ndarray,
-                   sat_height: np.ndarray) -> np.ndarray:
+                   *,
+                   sat_height: np.ndarray,
+                   es_height: np.ndarray,
+               ) -> np.ndarray:
     """Calculates the elevation angle from the earth station
     to space station, given earth and space station coordinates.
     Negative elevation angles means the space stations is not visible from Earth station.
@@ -87,7 +90,9 @@ def calc_elevation(Le: np.ndarray,
     ls : (ndarray)
         latitudes of the space station
     sat_height : (ndarray)
-        space station altitudes
+        space station altitudes in meters
+    es_height : (ndarray)
+        earth station altitudes in meters
 
     Returns
     -------
@@ -101,10 +106,11 @@ def calc_elevation(Le: np.ndarray,
     gamma = np.arccos(
         np.cos(Le) * np.cos(Ls) * np.cos(ls - le) + np.sin(Le) * np.sin(Ls)
     )
-    rs = EARTH_RADIUS_KM + sat_height
-    slant = np.sqrt(rs**2 + EARTH_RADIUS_KM**2 - 2 * rs * EARTH_RADIUS_KM * np.cos(gamma))
-    elev_angle = np.arccos((slant**2 + EARTH_RADIUS_KM**2 - rs**2) / \
-                           (2 * slant * EARTH_RADIUS_KM)) - np.pi / 2
+    rs = EARTH_RADIUS + sat_height
+    re = EARTH_RADIUS + es_height
+    slant = np.sqrt(rs**2 + re**2 - 2 * rs * re * np.cos(gamma))
+    elev_angle = np.arccos((slant**2 + re**2 - rs**2) / \
+                           (2 * slant * re)) - np.pi / 2
 
     return np.degrees(elev_angle)
 

--- a/sharc/satellite/utils/sat_utils.py
+++ b/sharc/satellite/utils/sat_utils.py
@@ -1,9 +1,9 @@
 import numpy as np
-from sharc.satellite.ngso.constants import EARTH_RADIUS
+from sharc.satellite.ngso.constants import EARTH_RADIUS_M
 
 
 def ecef2lla(x: np.ndarray, y: np.ndarray, z: np.ndarray) -> tuple:
-    """Coverts ECEF cartesian coordinates to lat long in WSG84 CRS.
+    """Coverts ECEF cartesian coordinates to lat long in spherical earth model.
 
     Parameters
     ----------
@@ -17,7 +17,7 @@ def ecef2lla(x: np.ndarray, y: np.ndarray, z: np.ndarray) -> tuple:
     Returns
     -------
     tuple (lat, long, alt)
-        lat long and altitude in WSG84 format
+        lat long and altitude in spherical earth model
     """
     x = np.atleast_1d(x)
     y = np.atleast_1d(y)
@@ -30,7 +30,7 @@ def ecef2lla(x: np.ndarray, y: np.ndarray, z: np.ndarray) -> tuple:
     lat = np.arctan2(z, xy)
 
     xyz = np.sqrt(x**2 + y**2 + z**2)
-    alt = xyz - EARTH_RADIUS
+    alt = xyz - EARTH_RADIUS_M
 
     lat = np.rad2deg(lat)
     lon = np.rad2deg(lon)
@@ -39,7 +39,7 @@ def ecef2lla(x: np.ndarray, y: np.ndarray, z: np.ndarray) -> tuple:
 
 
 def lla2ecef(lat: np.ndarray, lon: np.ndarray, alt: np.ndarray) -> tuple:
-    """Converts from geodetic WSG84 to ECEF coordinates
+    """Converts from spherical earth model lla to ECEF coordinates
 
     Parameters
     ----------
@@ -59,7 +59,7 @@ def lla2ecef(lat: np.ndarray, lon: np.ndarray, alt: np.ndarray) -> tuple:
     lon = np.atleast_1d(lon)
     alt = np.atleast_1d(alt)
 
-    r = (alt + EARTH_RADIUS)
+    r = (alt + EARTH_RADIUS_M)
     x = r * np.cos(np.deg2rad(lat)) * np.cos(np.deg2rad(lon))
     y = r * np.cos(np.deg2rad(lat)) * np.sin(np.deg2rad(lon))
     z = r * np.sin(np.deg2rad(lat))
@@ -106,8 +106,8 @@ def calc_elevation(Le: np.ndarray,
     gamma = np.arccos(
         np.cos(Le) * np.cos(Ls) * np.cos(ls - le) + np.sin(Le) * np.sin(Ls)
     )
-    rs = EARTH_RADIUS + sat_height
-    re = EARTH_RADIUS + es_height
+    rs = EARTH_RADIUS_M + sat_height
+    re = EARTH_RADIUS_M + es_height
     slant = np.sqrt(rs**2 + re**2 - 2 * rs * re * np.cos(gamma))
     elev_angle = np.arccos((slant**2 + re**2 - rs**2) / \
                            (2 * slant * re)) - np.pi / 2

--- a/sharc/support/sharc_geom.py
+++ b/sharc/support/sharc_geom.py
@@ -1,10 +1,12 @@
 import numpy as np
 import shapely as shp
-import typing
 import pyproj
+import scipy.spatial.transform
 
 from sharc.satellite.utils.sat_utils import lla2ecef, ecef2lla
 from sharc.station_manager import StationManager
+from sharc.support.sharc_utils import to_scalar
+from sharc.satellite.ngso.constants import EARTH_RADIUS
 
 
 def cartesian_to_polar(x: np.ndarray, y: np.ndarray, z: np.ndarray) -> tuple:
@@ -145,14 +147,13 @@ def rotate_angles_based_on_new_nadir(elev, azim, nadir_elev, nadir_azim):
     return res_elev, rotated_phi
 
 
+# NOTE: this works for both spherical an ellipsoidal Earth,
+# just need to change ecef2lla and lla2ecef implementations
+# TODO: refactor class and method names
 class GeometryConverter():
     """
-    This is a Singleton. set_reference should be called once per simulation/snapshot.
-
-    Alert:
-        Every conversion between polar and geodesic should be intermediated by cartesian.
-        Every transformation should be done either at cartesian or polar.
-        Ignore at your own risk (and sadness)
+    This class receives a reference lat, lon, alt and may transform other coordinate types
+    to local ENU
     """
     def __init__(self):
         # geodesical
@@ -165,31 +166,61 @@ class GeometryConverter():
         self.ref_y = None
         self.ref_z = None
 
-        # polar
-        self.ref_r = None
-        self.ref_azim = None
-        self.ref_elev = None
+        # rotation matrix used
+        self.translation = np.array([self.ref_x, self.ref_y, self.ref_z])
+        self.rotation = None
 
     def get_translation(self):
-        return self.ref_r
+        return self.ref_alt + EARTH_RADIUS
 
     def validate(self):
-        if None in [self.ref_elev, self.ref_azim, self.ref_r]:
+        if None in [self.ref_lat, self.ref_long, self.ref_alt]:
             raise ValueError("You need to set a reference for coordinate transformation before using it")
 
     def set_reference(self, ref_lat: float, ref_long: float, ref_alt: float):
-        self.ref_lat = ref_lat
-        self.ref_long = ref_long
-        self.ref_alt = ref_alt
+        self.ref_lat = to_scalar(ref_lat)
+        self.ref_long = to_scalar(ref_long)
+        self.ref_alt = to_scalar(ref_alt)
         ref_x, ref_y, ref_z = lla2ecef(self.ref_lat, self.ref_long, self.ref_alt)
-        self.ref_x = ref_x
-        self.ref_y = ref_y
-        self.ref_z = ref_z
+        self.ref_x = to_scalar(ref_x)
+        self.ref_y = to_scalar(ref_y)
+        self.ref_z = to_scalar(ref_z)
 
-        # polar coordinates
-        # geodesic doesn't necessarily translate one to one here
-        # so we use cartesian as intermediary
-        self.ref_r, self.ref_azim, self.ref_elev = cartesian_to_polar(ref_x, ref_y, ref_z)
+        # ECEF considers xy plane with x axis pointing at lon = 0,
+        # local coords considers x axis pointing towards East
+        # and y pointing towards North
+
+        # translate everything so ES is at (0, 0, 0)
+        self.translation = np.array([self.ref_x, self.ref_y, self.ref_z])
+
+        # considering:
+        # - that by definition the vector pointing East
+        #     is already orthogonal to ECEF z axis,
+        #     in other words, it is fully contained in the ECEF xy plane;
+        # Then, a single rotation around ECEF z can align local East and positive x
+        # Local east and ECEF x axis are parallel and with same direction at long=-90
+        # rotation around ECEF z = -90 - ref_lon
+        rotation_around_z = -self.ref_long - 90
+
+        # considering:
+        # - that the local zenith is orthogonal to local east;
+        # - that the local zenith unit vector can be found by using geodetic (lat, lon)
+        #    as polar coordinates (as follows from geodetic lat, lon definition)
+        # - that the local east is now fully contained in the x axis;
+        # Then the local zenith is fully contained in the yz plane,
+        # and a single rotation around the x axis aligns it with global z
+        # More specifically, z_vec = polar(lat, ref_long - ref_long) = polar(lat, 0)
+        # and so a rotation of 90 - lat is what is necessary
+        rotation_around_x = self.ref_lat - 90
+
+        # since ECEF follows left hand rule and local coordinates also do,
+        # x axis points to local East and z points to local zenith,
+        # y axis already is aligned with local North after transformation
+        self.rotation = scipy.spatial.transform.Rotation.from_euler(
+            'zx', [rotation_around_z, rotation_around_x], degrees=True
+        )
+        # can also be confirmed comparing to here:
+        # https://gssc.esa.int/navipedia/index.php/Transformations_between_ECEF_and_ENU_coordinates
 
     def convert_cartesian_to_transformed_cartesian(
         self, x, y, z, *, translate=None
@@ -198,46 +229,20 @@ class GeometryConverter():
         Transforms points by the same transformation required to bring reference to (0,0,0)
         You can only rotate by specifying translate=0
         """
-        ref_elev = self.ref_elev
-        ref_azim = self.ref_azim
-        ref_r = self.ref_r
-
         self.validate()
 
-        # calculate distances to the centre of the Earth
-        dist_sat_centre_earth_km, azim, elev = cartesian_to_polar(x, y, z)
+        translate_val = self.translation
+        if translate is not None:
+            translate_val = np.atleast_1d(translate)
 
-        dist_imt_centre_earth = translate
-        if translate is None:
-            dist_imt_centre_earth = ref_r
+        # broadcast translate to have same number of dimensions as expected
+        xyz = np.stack([x, y, z], axis=-1)  # Nx3
 
-        # calculate Cartesian coordinates of , with origin at centre of the Earth,
-        # but considering the x axis at same longitude as the ref_long
-        # so that we can rotate around y to bring reference to top
-        sat_lat_rad = np.deg2rad(elev)
-        # consider coordinates rotating ref_long clockwise around z axis
-        imt_long_diff_rad = np.deg2rad(azim - ref_azim)
-        x1 = dist_sat_centre_earth_km * \
-            np.cos(sat_lat_rad) * np.cos(imt_long_diff_rad)
-        y1 = dist_sat_centre_earth_km * \
-            np.cos(sat_lat_rad) * np.sin(imt_long_diff_rad)
+        rshp = (xyz.ndim - 1) * (1,) + translate_val.shape
+        xyz = xyz - translate_val.reshape(rshp)
 
-        # didn't transform, shoud eq height
-        z1 = dist_sat_centre_earth_km * np.sin(sat_lat_rad)
-
-        # rotate axis and calculate coordinates with origin at IMT system
-        imt_lat_rad = np.deg2rad(ref_elev)
-        x2 = (
-            x1 * np.sin(imt_lat_rad) - z1 * np.cos(imt_lat_rad)
-        )
-
-        y2 = y1
-
-        z2 = (
-            z1 * np.sin(imt_lat_rad) + x1 * np.cos(imt_lat_rad)
-        ) - dist_imt_centre_earth
-
-        return (x2, y2, z2)
+        # rotate so axis are same as ENU
+        return self.rotation.apply(xyz).T
 
     def revert_transformed_cartesian_to_cartesian(
         self, x2, y2, z2, *, translate=None
@@ -247,40 +252,21 @@ class GeometryConverter():
         You can only rotate by specifying translate=0. You need to use the same 'translate' value used
         in transformation if you wish to reverse the transformation correctly
         """
-        ref_elev = self.ref_elev
-        ref_azim = self.ref_azim
-        ref_r = self.ref_r
-
         self.validate()
 
-        # rotate axis and calculate coordinates with origin at IMT system
-        imt_lat_rad = np.deg2rad(ref_elev)
+        # translate everything so ES is at (0, 0, 0)
+        translate_val = self.translation
+        if translate is not None:
+            translate_val = np.atleast_1d(translate)
 
-        dist_imt_centre_earth = translate
-        if translate is None:
-            dist_imt_centre_earth = ref_r
+        # broadcast translate to have same number of dimensions as expected
+        xyz = np.stack([x2, y2, z2], axis=-1)  # Nx3
 
-        # transposed transformation matrix
-        z2 = z2 + dist_imt_centre_earth
-        y1 = y2
-        x1 = x2 * np.sin(imt_lat_rad) + z2 * np.cos(imt_lat_rad)
-        z1 = z2 * np.sin(imt_lat_rad) - x2 * np.cos(imt_lat_rad)
+        # rotate xyz back to ecef coord system
+        xyz = self.rotation.apply(xyz, inverse=True)
 
-        dist_sat_centre_earth_km = np.sqrt(x1 * x1 + z1 * z1 + y1 * y1)
-        sat_lat_rad = np.arcsin(z1 / dist_sat_centre_earth_km)
-
-        imt_long_diff_rad = np.arctan2(
-            y1, x1
-        )
-
-        # calculate distances to the centre of the Earth
-        x, y, z = polar_to_cartesian(
-            dist_sat_centre_earth_km,
-            np.rad2deg(imt_long_diff_rad) + ref_azim,
-            np.rad2deg(sat_lat_rad)
-        )
-
-        return (x, y, z)
+        # translate earth reference back to its original ecef coord
+        return (xyz + translate_val[np.newaxis, :]).T
 
     def convert_lla_to_transformed_cartesian(
         self, lat: np.array, long: np.array, alt: np.array
@@ -306,7 +292,6 @@ class GeometryConverter():
         if idx is specified, only stations[idx] will be converted
         """
         # transform positions
-        # print("(station.x, station.y, station.z)", (station.x[idx], station.y[idx], station.z[idx]))
         if idx is None:
             nx, ny, nz = self.convert_cartesian_to_transformed_cartesian(station.x, station.y, station.z)
         else:
@@ -355,7 +340,6 @@ class GeometryConverter():
         if idx is specified, only stations[idx] will be converted
         """
         # transform positions
-        # print("(station.x, station.y, station.z)", (station.x[idx], station.y[idx], station.z[idx]))
         if idx is None:
             nx, ny, nz = self.revert_transformed_cartesian_to_cartesian(station.x, station.y, station.z)
         else:

--- a/sharc/support/sharc_geom.py
+++ b/sharc/support/sharc_geom.py
@@ -6,7 +6,7 @@ import scipy.spatial.transform
 from sharc.satellite.utils.sat_utils import lla2ecef, ecef2lla
 from sharc.station_manager import StationManager
 from sharc.support.sharc_utils import to_scalar
-from sharc.satellite.ngso.constants import EARTH_RADIUS
+from sharc.satellite.ngso.constants import EARTH_RADIUS_M
 
 
 def cartesian_to_polar(x: np.ndarray, y: np.ndarray, z: np.ndarray) -> tuple:
@@ -171,7 +171,7 @@ class GeometryConverter():
         self.rotation = None
 
     def get_translation(self):
-        return self.ref_alt + EARTH_RADIUS
+        return self.ref_alt + EARTH_RADIUS_M
 
     def validate(self):
         if None in [self.ref_lat, self.ref_long, self.ref_alt]:

--- a/sharc/support/sharc_utils.py
+++ b/sharc/support/sharc_utils.py
@@ -1,3 +1,6 @@
+import numpy as np
+
+
 def is_float(s: str) -> bool:
     """Check if string represents a float value
 
@@ -16,3 +19,9 @@ def is_float(s: str) -> bool:
         return True
     except ValueError:
         return False
+
+
+def to_scalar(x):
+    if isinstance(x, np.ndarray):
+        return x.item()  # Works for 0-D or 1-element arrays
+    return x

--- a/tests/test_geometry_converter.py
+++ b/tests/test_geometry_converter.py
@@ -1,0 +1,202 @@
+import unittest
+import numpy as np
+import numpy.testing as npt
+from sharc.support.sharc_geom import GeometryConverter
+from sharc.satellite.utils.sat_utils import ecef2lla, lla2ecef
+from sharc.station_manager import StationManager
+
+
+class TestGeometryConverter(unittest.TestCase):
+    def setUp(self):
+        self.conv0_0km = GeometryConverter()
+        self.conv0_0km.set_reference(
+            0, 0, 0
+        )
+        self.conv0_52km = GeometryConverter()
+        self.conv0_52km.set_reference(
+            0, 0, 52e3
+        )
+
+        self.conv1_0km = GeometryConverter()
+        self.conv1_0km.set_reference(
+            -15, -47, 0
+        )
+        self.conv1_10km = GeometryConverter()
+        self.conv1_10km.set_reference(
+            -15, -47, 10e3
+        )
+
+        self.all_converters = [
+            self.conv0_0km,
+            self.conv0_52km,
+            self.conv1_0km,
+            self.conv1_10km,
+        ]
+
+    def test_set_reference(self):
+        """
+        Checking if set reference sets both lla and ecef coordinates
+        """
+        # negative x in xaxis
+        self.conv0_0km.set_reference(0, 180, 1200)
+        self.assertEqual(self.conv0_0km.ref_alt, 1200)
+        self.assertEqual(self.conv0_0km.ref_long, 180)
+        self.assertEqual(self.conv0_0km.ref_lat, 0)
+
+        # almost radius of earth
+        self.assertAlmostEqual(self.conv0_0km.ref_x, -6378145, delta=self.conv0_0km.ref_alt)
+        self.assertAlmostEqual(self.conv0_0km.ref_y, 0)
+        self.assertAlmostEqual(self.conv0_0km.ref_z, 0)
+
+        # positive x in xaxis
+        self.conv0_0km.set_reference(0, 0, 200)
+        self.assertEqual(self.conv0_0km.ref_alt, 200)
+        self.assertEqual(self.conv0_0km.ref_long, 0)
+        self.assertEqual(self.conv0_0km.ref_lat, 0)
+
+        # almost radius of earth
+        self.assertAlmostEqual(self.conv0_0km.ref_x, 6378145, delta=self.conv0_0km.ref_alt)
+        self.assertAlmostEqual(self.conv0_0km.ref_y, 0)
+        self.assertAlmostEqual(self.conv0_0km.ref_z, 0)
+
+    def test_reference_ecef(self):
+        for conv in self.all_converters:
+            lat, lon, alt = ecef2lla(conv.ref_x, conv.ref_y, conv.ref_z)
+            # ecef2lla approximation requires "almost equal" directive
+            print("conv.ref_lat", conv.ref_lat)
+            self.assertAlmostEqual(lat[0], conv.ref_lat, places=8)
+            self.assertAlmostEqual(lon[0], conv.ref_long, places=8)
+            self.assertAlmostEqual(alt[0], conv.ref_alt, places=8)
+
+    def test_ecef_to_enu(self):
+        """
+        Testing if ecef to enu works correctly
+        """
+        # for each converter defined at the setup
+        for conv in self.all_converters:
+            # check if reference point always goes to (0,0,0)
+            x, y, z = conv.convert_cartesian_to_transformed_cartesian(conv.ref_x, conv.ref_y, conv.ref_z)
+            self.assertEqual(x, 0)
+            self.assertEqual(y, 0)
+            self.assertEqual(z, 0)
+
+    def test_lla_to_enu(self):
+        """
+        Testing if lla to enu works correctly
+        """
+        # for each converter defined at the setup
+        for conv in self.all_converters:
+            x, y, z = conv.convert_lla_to_transformed_cartesian(conv.ref_lat, conv.ref_long, conv.ref_alt)
+            self.assertEqual(x, 0)
+            self.assertEqual(y, 0)
+            self.assertEqual(z, 0)
+
+    def test_enu_to_ecef(self):
+        """
+        Testing if enu to ecef works correctly
+        """
+        # for each converter defined at the setup
+        for conv in self.all_converters:
+            # check if the reverse is true
+            x, y, z = conv.revert_transformed_cartesian_to_cartesian(0, 0, 0)
+            self.assertEqual(x, conv.ref_x)
+            self.assertEqual(y, conv.ref_y)
+            self.assertEqual(z, conv.ref_z)
+
+    def test_station_converter(self):
+        """
+        Testing if station conversion works correctly
+        """
+        # for each converter defined at the setup
+        for conv in self.all_converters:
+            rng = np.random.default_rng(0)
+            n_samples = 100
+            stations = StationManager(n_samples)
+            # place stations randomly with ecef
+            xyz_bef = lla2ecef(
+                rng.uniform(-90, 90, n_samples),
+                rng.uniform(-180, 180, n_samples),
+                rng.uniform(0, 35e3, n_samples),
+            )
+            # set first station to be the reference
+            xyz_bef[0][0] = conv.ref_x
+            xyz_bef[1][0] = conv.ref_y
+            xyz_bef[2][0] = conv.ref_z
+            # point them randomly
+            azim_bef = rng.uniform(-180, 180, n_samples)
+            elev_bef = rng.uniform(-90, 90, n_samples)
+
+            stations.x, stations.y, stations.z = xyz_bef
+            stations.azimuth = azim_bef
+            stations.elevation = elev_bef
+
+            # get relative distances and off axis while in ecef
+            dists_bef = stations.get_3d_distance_to(stations)
+            off_axis_bef = stations.get_off_axis_angle(stations)
+
+            # convert stations to enu
+            conv.convert_station_3d_to_2d(stations)
+
+            # check if reference origin
+            self.assertEqual(stations.x[0], 0)
+            self.assertEqual(stations.y[0], 0)
+            self.assertEqual(stations.z[0], 0)
+
+            # get relative distances and off axis while in enu
+            dists_aft = stations.get_3d_distance_to(stations)
+            off_axis_aft = stations.get_off_axis_angle(stations)
+
+            # all stations should maintain same relative distances and off axis
+            # since their relative positioning and pointing should eq in ECEF and ENU
+            npt.assert_allclose(dists_aft, dists_bef)
+            npt.assert_allclose(off_axis_aft, off_axis_bef)
+
+            # NOTE: the next set of tests may not pass and the code still be correct...
+
+            # we can try to check if there are differences between stations before
+            # and after transformation.
+            # TODO: It would be more correct to not force equality for all cases,
+            # but only for most of them
+
+            # sometimes some values can be really similar before and after the transformation
+
+            # for example, reference may be on the same axis after and before transformation
+            # so we ignore the first station (used as reference) on these checks
+            npt.assert_equal(
+                np.abs(stations.x[1:] - xyz_bef[0][1:]) > 1e3,
+                True
+            )
+            npt.assert_equal(
+                np.abs(stations.y[1:] - xyz_bef[1][1:]) > 1e3,
+                True
+            )
+            npt.assert_equal(
+                np.abs(stations.z[1:] - xyz_bef[2][1:]) > 1e3,
+                True
+            )
+            # and the elevation angle may not change much if pointing vector is to the east/west
+            # since the pointing vector is aligned with the x axis, the rotation along it
+            # won't change the value much
+            npt.assert_equal(
+                np.abs(stations.azimuth - azim_bef) > 0.4,
+                True
+            )
+            npt.assert_equal(
+                np.abs(stations.elevation - elev_bef) > 0.4,
+                True
+            )
+
+            # return stations to starting case:
+            conv.revert_station_2d_to_3d(stations)
+
+            # check if their position is the same as at the start
+            # some precision error occurs, so "almost equal" is needed
+            npt.assert_almost_equal(stations.x, xyz_bef[0])
+            npt.assert_almost_equal(stations.y, xyz_bef[1])
+            npt.assert_almost_equal(stations.z, xyz_bef[2])
+            npt.assert_almost_equal(stations.azimuth, azim_bef)
+            npt.assert_almost_equal(stations.elevation, elev_bef)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_sat_utils.py
+++ b/tests/test_sat_utils.py
@@ -2,7 +2,7 @@ import unittest
 import numpy as np
 import numpy.testing as npt
 import sharc.satellite.utils.sat_utils as sat_utils
-from sharc.satellite.ngso.constants import EARTH_RADIUS
+from sharc.satellite.ngso.constants import EARTH_RADIUS_M
 
 
 class TestSatUtils(unittest.TestCase):
@@ -12,16 +12,16 @@ class TestSatUtils(unittest.TestCase):
 
     def test_ecef2lla(self):
         # Object is over the meridional plane at 1414km of altitude
-        sx1 = EARTH_RADIUS + 1414e3
+        sx1 = EARTH_RADIUS_M + 1414e3
         sy1 = 0.0
         sz1 = 0.0
         lat, lng, alt = sat_utils.ecef2lla(sx1, sy1, sz1)
         npt.assert_almost_equal(lat, 0.0, 2)
         npt.assert_almost_equal(lng, 0.0, 2)
-        npt.assert_almost_equal(alt, sx1 - EARTH_RADIUS, 1)
+        npt.assert_almost_equal(alt, sx1 - EARTH_RADIUS_M, 1)
 
         # Object is over the meridional plane at sea level
-        sx2 = EARTH_RADIUS
+        sx2 = EARTH_RADIUS_M
         sy2 = 0.0
         sz2 = 0.0
         lat, lng, alt = sat_utils.ecef2lla(sx2, sy2, sz2)
@@ -29,7 +29,7 @@ class TestSatUtils(unittest.TestCase):
         npt.assert_almost_equal(lng, 0.0, 2)
         npt.assert_almost_equal(alt, 0.0, 1)
 
-        r = EARTH_RADIUS + 4209582
+        r = EARTH_RADIUS_M + 4209582
         expected_lat = 18.0316
         expected_lon = 39.30153
         sx3 = r * np.cos(np.deg2rad(expected_lat)) * np.cos(np.deg2rad(expected_lon))
@@ -39,7 +39,7 @@ class TestSatUtils(unittest.TestCase):
         lat, lng, alt = sat_utils.ecef2lla(sx3, sy3, sz3)
         npt.assert_almost_equal(lat, expected_lat, 3)
         npt.assert_almost_equal(lng, expected_lon, 3)
-        npt.assert_almost_equal(alt, r - EARTH_RADIUS, 1)
+        npt.assert_almost_equal(alt, r - EARTH_RADIUS_M, 1)
 
         # test the array form
         sx = [sx1, sx2, sx3]
@@ -57,7 +57,7 @@ class TestSatUtils(unittest.TestCase):
         alt = 1414000.0
         sx, sy, sz = sat_utils.lla2ecef(lat, lng, alt)
 
-        npt.assert_almost_equal(sx, alt + EARTH_RADIUS, 1)
+        npt.assert_almost_equal(sx, alt + EARTH_RADIUS_M, 1)
         npt.assert_almost_equal(sy, 0.0, 1)
         npt.assert_almost_equal(sz, 0.0, 1)
 
@@ -66,7 +66,7 @@ class TestSatUtils(unittest.TestCase):
         lng = 0.0
         alt = 0.0
         sx, sy, sz = sat_utils.lla2ecef(lat, lng, alt)
-        npt.assert_almost_equal(sx, EARTH_RADIUS, 1)
+        npt.assert_almost_equal(sx, EARTH_RADIUS_M, 1)
         npt.assert_almost_equal(sy, 0.0, 1)
         npt.assert_almost_equal(sz, 0.0, 1)
 
@@ -83,7 +83,7 @@ class TestSatUtils(unittest.TestCase):
         lng = [0.0, 0.0, 46.839308]
         alt = [1414000.0, 0.0, 141400.0]
         sx, sy, sz = sat_utils.lla2ecef(lat, lng, alt)
-        npt.assert_almost_equal(sx, [1414000.0 + EARTH_RADIUS, EARTH_RADIUS, 3259772.4], 1)
+        npt.assert_almost_equal(sx, [1414000.0 + EARTH_RADIUS_M, EARTH_RADIUS_M, 3259772.4], 1)
         npt.assert_almost_equal(sy, [0.0, 0.0, 3476081.0], 1)
         npt.assert_almost_equal(sz, [0.0, 0.0, 4449180.9], 1)
 

--- a/tests/test_sat_utils.py
+++ b/tests/test_sat_utils.py
@@ -102,11 +102,11 @@ class TestSatUtils(unittest.TestCase):
             (0.0, -30.0),
         ]
 
-        space_station_alts_km = [
-            1414,
-            525,
-            340,
-            35786,
+        space_station_alts = [
+            1414 * 1e3,
+            525 * 1e3,
+            340 * 1e3,
+            35786 * 1e3,
         ]
 
         expected_elevations = [
@@ -122,7 +122,8 @@ class TestSatUtils(unittest.TestCase):
                 space_station_coords[i][0],
                 earth_station_coords[i][1],
                 space_station_coords[i][1],
-                space_station_alts_km[i],
+                sat_height=space_station_alts[i],
+                es_height=0
             )
             npt.assert_almost_equal(e, expected_elevations[i], 1)
 

--- a/tests/test_sat_utils.py
+++ b/tests/test_sat_utils.py
@@ -2,6 +2,7 @@ import unittest
 import numpy as np
 import numpy.testing as npt
 import sharc.satellite.utils.sat_utils as sat_utils
+from sharc.satellite.ngso.constants import EARTH_RADIUS
 
 
 class TestSatUtils(unittest.TestCase):
@@ -11,35 +12,39 @@ class TestSatUtils(unittest.TestCase):
 
     def test_ecef2lla(self):
         # Object is over the meridional plane at 1414km of altitude
-        sx = 7792137.0
-        sy = 0.0
-        sz = 0.0
-        lat, lng, alt = sat_utils.ecef2lla(sx, sy, sz)
+        sx1 = EARTH_RADIUS + 1414e3
+        sy1 = 0.0
+        sz1 = 0.0
+        lat, lng, alt = sat_utils.ecef2lla(sx1, sy1, sz1)
         npt.assert_almost_equal(lat, 0.0, 2)
         npt.assert_almost_equal(lng, 0.0, 2)
-        npt.assert_almost_equal(alt, 1414000.0, 1)
+        npt.assert_almost_equal(alt, sx1 - EARTH_RADIUS, 1)
 
         # Object is over the meridional plane at sea level
-        sx = 6378137.0
-        sy = 0.0
-        sz = 0.0
-        lat, lng, alt = sat_utils.ecef2lla(sx, sy, sz)
+        sx2 = EARTH_RADIUS
+        sy2 = 0.0
+        sz2 = 0.0
+        lat, lng, alt = sat_utils.ecef2lla(sx2, sy2, sz2)
         npt.assert_almost_equal(lat, 0.0, 2)
         npt.assert_almost_equal(lng, 0.0, 2)
         npt.assert_almost_equal(alt, 0.0, 1)
 
-        sx = 7792137.0
-        sy = 6378137.0
-        sz = 3264751.4
-        lat, lng, alt = sat_utils.ecef2lla(sx, sy, sz)
-        npt.assert_almost_equal(lat, 18.0316, 3)
-        npt.assert_almost_equal(lng, 39.30153, 3)
-        npt.assert_almost_equal(alt, 4209582, 1)
+        r = EARTH_RADIUS + 4209582
+        expected_lat = 18.0316
+        expected_lon = 39.30153
+        sx3 = r * np.cos(np.deg2rad(expected_lat)) * np.cos(np.deg2rad(expected_lon))
+        sy3 = r * np.cos(np.deg2rad(expected_lat)) * np.sin(np.deg2rad(expected_lon))
+        sz3 = r * np.sin(np.deg2rad(expected_lat))
+
+        lat, lng, alt = sat_utils.ecef2lla(sx3, sy3, sz3)
+        npt.assert_almost_equal(lat, expected_lat, 3)
+        npt.assert_almost_equal(lng, expected_lon, 3)
+        npt.assert_almost_equal(alt, r - EARTH_RADIUS, 1)
 
         # test the array form
-        sx = [7792137.0, 6378137.0, 7792137.0]
-        sy = [0.0, 0.0, 6378137.0]
-        sz = [0.0, 0.0, 3264751.4]
+        sx = [sx1, sx2, sx3]
+        sy = [sy1, sy2, sy3]
+        sz = [sz1, sz2, sz3]
         lat, lng, alt = sat_utils.ecef2lla(sx, sy, sz)
         npt.assert_almost_equal(lat, [0.0, 0.0, 18.0316], 3)
         npt.assert_almost_equal(lng, [0.0, 0.0, 39.30153], 3)
@@ -51,7 +56,8 @@ class TestSatUtils(unittest.TestCase):
         lng = 0.0
         alt = 1414000.0
         sx, sy, sz = sat_utils.lla2ecef(lat, lng, alt)
-        npt.assert_almost_equal(sx, 7792137.0, 1)
+
+        npt.assert_almost_equal(sx, alt + EARTH_RADIUS, 1)
         npt.assert_almost_equal(sy, 0.0, 1)
         npt.assert_almost_equal(sz, 0.0, 1)
 
@@ -60,7 +66,7 @@ class TestSatUtils(unittest.TestCase):
         lng = 0.0
         alt = 0.0
         sx, sy, sz = sat_utils.lla2ecef(lat, lng, alt)
-        npt.assert_almost_equal(sx, 6378137.0, 1)
+        npt.assert_almost_equal(sx, EARTH_RADIUS, 1)
         npt.assert_almost_equal(sy, 0.0, 1)
         npt.assert_almost_equal(sz, 0.0, 1)
 
@@ -68,18 +74,18 @@ class TestSatUtils(unittest.TestCase):
         lng = 46.839308
         alt = 141400.0
         sx, sy, sz = sat_utils.lla2ecef(lat, lng, alt)
-        npt.assert_almost_equal(sx, 3264751.4, 1)
-        npt.assert_almost_equal(sy, 3481390.4, 1)
-        npt.assert_almost_equal(sz, 4426792.5, 1)
+        npt.assert_almost_equal(sx, 3259772.4, 1)
+        npt.assert_almost_equal(sy, 3476081.0, 1)
+        npt.assert_almost_equal(sz, 4449180.9, 1)
 
         # test the array form
         lat = [0.0, 0.0, 43.0344]
         lng = [0.0, 0.0, 46.839308]
         alt = [1414000.0, 0.0, 141400.0]
         sx, sy, sz = sat_utils.lla2ecef(lat, lng, alt)
-        npt.assert_almost_equal(sx, [7792137.0, 6378137.0, 3264751.4], 1)
-        npt.assert_almost_equal(sy, [0.0, 0.0, 3481390.4], 1)
-        npt.assert_almost_equal(sz, [0.0, 0.0, 4426792.5], 1)
+        npt.assert_almost_equal(sx, [1414000.0 + EARTH_RADIUS, EARTH_RADIUS, 3259772.4], 1)
+        npt.assert_almost_equal(sy, [0.0, 0.0, 3476081.0], 1)
+        npt.assert_almost_equal(sz, [0.0, 0.0, 4449180.9], 1)
 
     def test_calculate_elev_angle(self):
         earth_station_coords = [

--- a/tests/test_station_factory_ngso.py
+++ b/tests/test_station_factory_ngso.py
@@ -89,11 +89,9 @@ class StationFactoryNgsoTest(unittest.TestCase):
         earth_center.x = np.array([0.])
         earth_center.y = np.array([0.])
         x, y, z = lla2ecef(self.lat, self.long, self.alt)
-        earth_center.z = np.array([
-            -np.sqrt(
-                x * x + y * y + z * z,
-            ),
-        ])
+        earth_center.z = -np.sqrt(
+            x * x + y * y + z * z,
+        )
 
         self.assertNotAlmostEqual(earth_center.z[0], 0.)
 

--- a/tests/test_topology_imt_mss_dc.py
+++ b/tests/test_topology_imt_mss_dc.py
@@ -127,8 +127,7 @@ class TestTopologyImtMssDc(unittest.TestCase):
             ),
         )
         # Add a tolerance to the elevation angle because of the Earth oblateness
-        expected_atol = 2e-2
-        npt.assert_array_less(min_elevation_angle - expected_atol, xy_plane_elevations)
+        npt.assert_array_less(min_elevation_angle, xy_plane_elevations)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Before, implementation partly considered earth spherical and partly considered it an ellipsoid.
Now we consider it an sphere in ecef and lla conversions.

Now geometry converter converts from and to enu.

Now calc_elevation receives altitude in meters and can receive the earth station altitude.

An alternative implementation for ellispoid earth can be found here:
https://github.com/Radio-Spectrum/SHARC/tree/fix/geodesic_earth