### PR TITLE
fix(simulation): Fixes confusion on polarization loss setting.

### DIFF
--- a/sharc/parameters/parameters_haps.py
+++ b/sharc/parameters/parameters_haps.py
@@ -50,6 +50,8 @@ class ParametersHaps(ParametersBase):
     # design, and has a maximum value of −25 dB
     antenna_l_n: float = -25.0
 
+    polarization_loss: float | None = None  # Polarization loss [dB]
+
     def load_parameters_from_file(self, config_file: str):
         """Load the parameters from file an run a sanity check
 

--- a/sharc/parameters/parameters_ras.py
+++ b/sharc/parameters/parameters_ras.py
@@ -11,4 +11,4 @@ class ParametersRas(ParametersSingleEarthStation):
     Simulation parameters for Radio Astronomy Service
     """
     section_name: str = "ras"
-    polarization_loss: float = 0.0
+    polarization_loss: float | None = None

--- a/sharc/parameters/parameters_single_earth_station.py
+++ b/sharc/parameters/parameters_single_earth_station.py
@@ -27,7 +27,7 @@ class ParametersSingleEarthStation(ParametersBase):
     # NOTE: Verification needed:
     # polarization mismatch between IMT BS and linear polarization = 3dB in earth P2P case?
     # = 0 is safer choice
-    polarization_loss: float = 3.0
+    polarization_loss: float | None = None
 
     # Sensor center frequency [MHz]
     frequency: float = None  # Center frequency of the sensor in MHz

--- a/sharc/parameters/parameters_single_space_station.py
+++ b/sharc/parameters/parameters_single_space_station.py
@@ -39,7 +39,7 @@ class ParametersSingleSpaceStation(ParametersBase):
     # e.g. could come from polarization mismatch or depolarization
     # check if IMT parameters don't come in values for single polarization
     # before adding loss here
-    polarization_loss: float = 0.0
+    polarization_loss: float | None = None
 
     # Channel model, possible values are "FSPL" (free-space path loss), "P619"
     channel_model: typing.Literal[

--- a/sharc/simulation.py
+++ b/sharc/simulation.py
@@ -230,9 +230,20 @@ class Simulation(ABC, Observable):
         )
 
         if hasattr(self.param_system, "polarization_loss"):
-            self.polarization_loss = self.param_system.polarization_loss
+            if self.param_system.polarization_loss is not None:
+                # if polarization loss is defined, use it
+                # otherwise, raise an error.
+                self.polarization_loss = self.param_system.polarization_loss
+            else:
+                raise ValueError(
+                    "Polarization loss is not initialized in the system parameters. "
+                    "Please initialized it in the system parameters file."
+                )
         else:
-            self.polarization_loss = 3.0
+            raise ValueError(
+                "Polarization loss is not defined in the system parameters. "
+                "Please define it in the system parameters file."
+            )
 
     def finalize(self, *args, **kwargs):
         """

--- a/tests/test_adjacent_channel.py
+++ b/tests/test_adjacent_channel.py
@@ -141,6 +141,7 @@ class SimulationAdjacentTest(unittest.TestCase):
         self.param.fss_ss.time_ratio = 0.5
         self.param.fss_ss.antenna_l_s = -20
         self.param.fss_ss.acs = 10
+        self.param.fss_ss.polarization_loss = 3.0
 
     def test_simulation_2bs_4ue_downlink(self):
         self.param.general.imt_link = "DOWNLINK"

--- a/tests/test_simulation_downlink.py
+++ b/tests/test_simulation_downlink.py
@@ -138,6 +138,7 @@ class SimulationDownlinkTest(unittest.TestCase):
         self.param.fss_ss.time_ratio = 0.5
         self.param.fss_ss.antenna_l_s = -20
         self.param.fss_ss.acs = 0
+        self.param.fss_ss.polarization_loss = 3.0
 
         self.param.fss_es.x = -5000
         self.param.fss_es.y = 0
@@ -155,6 +156,7 @@ class SimulationDownlinkTest(unittest.TestCase):
         self.param.fss_es.channel_model = "FSPL"
         self.param.fss_es.line_of_sight_prob = 1
         self.param.fss_es.acs = 0
+        self.param.fss_es.polarization_loss = 3.0
 
         self.param.ras.geometry.location.type = "FIXED"
         self.param.ras.geometry.location.x = -5000
@@ -174,6 +176,7 @@ class SimulationDownlinkTest(unittest.TestCase):
         self.param.ras.channel_model = "FSPL"
         self.param.ras.line_of_sight_prob = 1
         self.param.ras.tx_power_density = -500
+        self.param.ras.polarization_loss = 0.0
 
     def test_simulation_2bs_4ue_fss_ss(self):
         self.param.general.system = "FSS_SS"

--- a/tests/test_simulation_downlink_haps.py
+++ b/tests/test_simulation_downlink_haps.py
@@ -135,6 +135,7 @@ class SimulationDownlinkHapsTest(unittest.TestCase):
         self.param.haps.season = "SUMMER"
         self.param.haps.channel_model = "FSPL"
         self.param.haps.antenna_l_n = -25
+        self.param.haps.polarization_loss = 3.0
 
     def test_simulation_2bs_4ue_1haps(self):
         """

--- a/tests/test_simulation_downlink_tvro.py
+++ b/tests/test_simulation_downlink_tvro.py
@@ -130,6 +130,7 @@ class SimulationDownlinkTvroTest(unittest.TestCase):
         self.param.fss_es.antenna_envelope_gain = 0
         self.param.fss_es.channel_model = "FSPL"
         self.param.fss_es.line_of_sight_prob = 1
+        self.param.fss_es.polarization_loss = 3.0
 
     def test_simulation_1bs_1ue_tvro(self):
         self.param.general.system = "FSS_ES"

--- a/tests/test_simulation_indoor.py
+++ b/tests/test_simulation_indoor.py
@@ -136,6 +136,7 @@ class SimulationIndoorTest(unittest.TestCase):
         self.param.fss_es.line_of_sight_prob = 1
         self.param.fss_es.adjacent_ch_selectivity = 0
         self.param.fss_es.diameter = 0.74
+        self.param.fss_es.polarization_loss = 3.0
 
     def test_simulation_fss_es(self):
         # Initialize stations

--- a/tests/test_simulation_uplink.py
+++ b/tests/test_simulation_uplink.py
@@ -131,6 +131,7 @@ class SimulationUplinkTest(unittest.TestCase):
         self.param.fss_ss.time_ratio = 0.5
         self.param.fss_ss.antenna_l_s = -20
         self.param.fss_ss.acs = 0
+        self.param.fss_ss.polarization_loss = 3.0
 
         self.param.fss_es.x = -5000
         self.param.fss_es.y = 0
@@ -148,6 +149,7 @@ class SimulationUplinkTest(unittest.TestCase):
         self.param.fss_es.channel_model = "FSPL"
         self.param.fss_es.line_of_sight_prob = 1
         self.param.fss_es.acs = 0
+        self.param.fss_es.polarization_loss = 3.0
 
         self.param.ras.geometry.location.type = "FIXED"
         self.param.ras.geometry.location.fixed.x = -5000
@@ -167,9 +169,7 @@ class SimulationUplinkTest(unittest.TestCase):
         self.param.ras.antenna.pattern = "OMNI"
         self.param.ras.channel_model = "FSPL"
         self.param.ras.line_of_sight_prob = 1
-        self.param.ras.BOLTZMANN_CONSTANT = 1.38064852e-23
-        self.param.ras.EARTH_RADIUS = 6371000
-        self.param.ras.SPEED_OF_LIGHT = 299792458
+        self.param.ras.polarization_loss = 0.0
 
     def test_simulation_2bs_4ue_ss(self):
         self.param.general.system = "FSS_SS"


### PR DESCRIPTION
Fixes confusion on polarization loss setting.
- Now the user must define and initialize the polarization_loss
    attribute in system parameters.
- If not defined nor set the simulation will throw an error.