### PR TITLE
fix: bs bandwidth

### DIFF
--- a/sharc/simulation.py
+++ b/sharc/simulation.py
@@ -505,7 +505,7 @@ class Simulation(ABC, Observable):
         bs_active = np.where(self.bs.active)[0]
         for bs in bs_active:
             ue = self.link[bs]
-            self.bs.bandwidth[bs] = self.num_rb_per_ue * \
+            self.bs.bandwidth[bs] = self.num_rb_per_bs * \
                 self.parameters.imt.rb_bandwidth
             self.ue.bandwidth[ue] = self.num_rb_per_ue * \
                 self.parameters.imt.rb_bandwidth


### PR DESCRIPTION
This fixes imt bs bandwidth calculation.

It affects thermal noise and every variable that depends on it, such as total interference, sinr, snr and inr.

The problem was that changing `k` number of UE's divided the BS bandwidth by `k` when it shouldn't. This variable was used only on BS `thermal_noise` calculation, affecting only it and its dependencies.

![image](https://github.com/user-attachments/assets/4e55206a-9e54-4d73-a20f-e7d47acd97f3)