### PR TITLE
update: imt DL victim adj channel simulation works the same way as UL

### DIFF
--- a/sharc/parameters/imt/parameters_imt.py
+++ b/sharc/parameters/imt/parameters_imt.py
@@ -39,6 +39,8 @@ class ParametersImt(ParametersBase):
         height: float = 6.0
         noise_figure: float = 10.0
         ohmic_loss: float = 3.0
+        # Adjacent Channel Selectivity in dB
+        adjacent_ch_selectivity: float = None
         antenna: ParametersAntenna = field(default_factory=lambda: ParametersAntenna(
             pattern="ARRAY", array=ParametersAntennaImt(downtilt=0.0)
         ))

--- a/sharc/simulation_downlink.py
+++ b/sharc/simulation_downlink.py
@@ -241,6 +241,7 @@ class SimulationDownlink(Simulation):
 
                     for i, center_freq, bw in zip(range(len(center_freqs)), center_freqs, ue_bws):
                         # calculate tx emissions in UE in use bandwidth only
+                        # [dB]
                         tx_oob[i] = self.system.spectral_mask.power_calc(
                             center_freq,
                             bw
@@ -254,6 +255,8 @@ class SimulationDownlink(Simulation):
                         self.param_system.adjacent_ch_leak_ratio + \
                         10 * np.log10(1. - weights)
                 elif self.param_system.adjacent_ch_emissions == "OFF":
+                    pass
+                elif self.parameters.imt.adjacent_ch_reception is False:
                     pass
                 else:
                     raise ValueError(

--- a/sharc/simulation_uplink.py
+++ b/sharc/simulation_uplink.py
@@ -178,19 +178,80 @@ class SimulationUplink(Simulation):
         oob_power = -500
         oob_interf_lin = 0
         if self.adjacent_channel:
-            if self.parameters.imt.adjacent_interf_model == "SPECTRAL_MASK":
-                # Out-of-band power in the adjacent channel.
-                oob_power = self.system.spectral_mask.power_calc(self.parameters.imt.frequency,
-                                                                 self.parameters.imt.bandwidth)
-                oob_interf_lin = np.power(10, 0.1 * oob_power) / \
-                    np.power(10, 0.1 * self.parameters.imt.bs_adjacent_ch_selectivity)
-            elif self.parameters.imt.adjacent_interf_model == "ACIR":
-                acir = -10 * np.log10(10**(-self.param_system.adjacent_ch_leak_ratio / 10) +
-                                      10**(-self.parameters.imt.bs_adjacent_ch_selectivity / 10))
-                oob_power = self.param_system.tx_power_density + \
+            # emissions outside of tx bandwidth and inside of rx bw
+            # due to oob emissions on tx side
+            tx_oob = -500
+
+            # emissions outside of rx bw and inside of tx bw
+            # due to non ideal filtering on rx side
+            # will be the same for all UE's, only considering
+            rx_oob = -500
+
+            # TODO: M.2101 states that:
+            # "The ACIR value should be calculated based on per UE allocated number of resource blocks"
+
+            # should we actually implement that for ACS since the receiving filter is fixed?
+
+            # or maybe ignore ACS altogether (ACS = inf)? If we consider only allocated RB, it makes
+            # no sense to use ACS.
+            # At the same time, ignoring ACS doesn't seem correct since the interference
+            # could DECREASE when it would make sense for it to increase.
+            # e.g. adjacent systems -> slightly co-channel with ACS = inf
+            # should interfer ^        less than this ^
+
+            # Unless we never use ACS..?
+            if self.parameters.imt.adjacent_ch_reception == "ACS":
+                if self.overlapping_bandwidth:
+                    if not hasattr(self, "ALREADY_WARNED_ABOUT_ACS_WHEN_OVERLAPPING_BAND"):
+                        print(
+                            "[WARNING]: You're trying to use ACS on a partially overlapping band"
+                            "with UEs. Verify the code implements the behavior you expect"
+                        )
+                        self.ALREADY_WARNED_ABOUT_ACS_WHEN_OVERLAPPING_BAND = True
+                # only apply ACS over non overlapping bw
+                p_tx = self.param_system.tx_power_density \
+                        + 10 * np.log10(
+                            (self.param_system.bandwidth - self.overlapping_bandwidth) * 1e6
+                        )
+
+                rx_oob = p_tx - self.parameters.imt.bs.adjacent_ch_selectivity
+            elif self.parameters.imt.adjacent_ch_reception == "OFF":
+                pass
+            else:
+                raise ValueError(
+                    f"No implementation for parameters.imt.adjacent_ch_reception == {self.parameters.imt.adjacent_ch_reception}"
+                )
+
+            # for tx oob we accept ACLR and spectral mask
+            if self.param_system.adjacent_ch_emissions == "SPECTRAL_MASK":
+                tx_oob = self.system.spectral_mask.power_calc(
+                    self.parameters.imt.frequency,
+                    self.parameters.imt.bandwidth * (
+                        1 - self.parameters.imt.guard_band_ratio
+                    )
+                ) - 30
+            elif self.param_system.adjacent_ch_emissions == "ACLR":
+                # consider ACLR only over non co-channel RBs
+                # This should diminish some of the ACLR interference
+                # in a way that make sense
+                tx_oob = self.param_system.tx_power_density + \
                     10 * np.log10(self.param_system.bandwidth * 1e6) -  \
-                    acir + 30
-                oob_interf_lin = 10**(oob_power / 10)
+                    self.param_system.adjacent_ch_leak_ratio
+            elif self.param_system.adjacent_ch_emissions == "OFF":
+                pass
+            else:
+                raise ValueError(
+                    f"No implementation for param_system.adjacent_ch_emissions == {self.param_system.adjacent_ch_emissions}"
+                )
+
+            # Out of band power
+            # sum linearly power leaked into band and power received in the adjacent band
+
+            oob_power = 10 * np.log10(
+                10 ** (0.1 * tx_oob) + 10 ** (0.1 * rx_oob)
+            )
+            # repeat ue received power for each coupling loss
+            oob_interf_lin = np.power(10, 0.1 * oob_power)
 
         ext_interference = 10 * np.log10(np.power(10, 0.1 * in_band_interf) + oob_interf_lin)
 


### PR DESCRIPTION
Currently, adjacent channel interference works differently for UL and DL when IMT is victim.

This PR makes it so that both ways work the same way:

WE DO NOT CONSIDER FDR. That makes it so the calculation is not quiite right when partial overlapping with both ACS and ACLR are considered. But you can still calculate your own ACLR and ACS values to make it so the equation reaches the correct result.

You can see from M2101 that ACIR (adjacent channel interference ratio) is defined by `1/acir = 1/aclr + 1/acs` (linear). So
`p_tx/acir = p_tx/aclr + p_tx/acs`.

So you can consider two sources of adjacent channel interference:
1. (ACS): The transmitters emissions **outside** of its band and **inside** of the receivers band (e.g. rx filter imperfections);
2. (ACLR/Spectral mask for emissions): The transmitters emissions **inside** of its band and **outside** of the receivers band;

These sources are added with co-channel interference over overlapping bandwidth.