### PR TITLE
fix: hotspot undeclared variable used

### DIFF
--- a/sharc/topology/topology_hotspot.py
+++ b/sharc/topology/topology_hotspot.py
@@ -138,10 +138,10 @@ class TopologyHotspot(Topology):
 
         self.x = x
         self.y = y
-        self.z = np.zeros(self.num_base_stations)
         self.azimuth = azimuth
         # In the end, we have to update the number of base stations
         self.num_base_stations = len(self.x)
+        self.z = np.zeros(self.num_base_stations)
         self.indoor = np.zeros(self.num_base_stations, dtype=bool)
 
     def overlapping_hotspots(

--- a/tests/test_topology_hotspot.py
+++ b/tests/test_topology_hotspot.py
@@ -41,20 +41,21 @@ class TopologyHotspotTest(unittest.TestCase):
             s_diff = np.abs(sr - s)
 
             c1 = (q_diff > r_diff) & (q_diff > s_diff)
-            qr[c1] = -rr[c1] -sr[c1]
+            qr[c1] = -rr[c1] - sr[c1]
 
-            c2 = (r_diff > s_diff) &  (~c1)
-            rr[c2] = -qr[c2] -sr[c2]
+            c2 = (r_diff > s_diff) & (~c1)
+            rr[c2] = -qr[c2] - sr[c2]
 
             c3 = (~c1) & (~c2)
-            sr[c3] = -qr[c3] -rr[c3]
+            sr[c3] = -qr[c3] - rr[c3]
 
             return qr, rr, sr
 
         def cube_to_axial(q, r, s):
             return q, r
+
         def axial_to_cube(q, r):
-            return q, r, -q -r
+            return q, r, -q - r
 
         def axial_round(q, r):
             return cube_to_axial(*cube_round(*axial_to_cube(q, r)))
@@ -72,6 +73,7 @@ class TopologyHotspotTest(unittest.TestCase):
 
             return axial_round(q, r)
 
+        # Test for 1 hotspot in 1 cluster grid
         n_hexagons = 19 * 3
 
         rng = np.random.RandomState(11111)
@@ -103,7 +105,7 @@ class TopologyHotspotTest(unittest.TestCase):
         self.assertEqual(len(count), n_hexagons)
         npt.assert_array_equal(list(count.values()), 1)
 
-
+        # Test for 3 hotspots in 1 cluster grid
         param.num_hotspots_per_cell = 3
         topology = TopologyHotspot(
             param, intersite_distance, num_clusters,
@@ -126,7 +128,7 @@ class TopologyHotspotTest(unittest.TestCase):
         self.assertEqual(len(count), n_hexagons)
         npt.assert_array_equal(list(count.values()), 3)
 
-
+        # Test for 3 hotspots in 7 cluster grid
         n_hexagons = 19 * 3 * 7
         num_clusters = 7
         topology = TopologyHotspot(

--- a/tests/test_topology_hotspot.py
+++ b/tests/test_topology_hotspot.py
@@ -7,7 +7,8 @@ Created on Tue May 23 16:43:09 2017
 
 import unittest
 import numpy as np
-# import numpy.testing as npt
+import numpy.testing as npt
+from collections import Counter
 
 from sharc.parameters.imt.parameters_hotspot import ParametersHotspot
 from sharc.topology.topology_hotspot import TopologyHotspot
@@ -29,6 +30,124 @@ class TopologyHotspotTest(unittest.TestCase):
         self.topology = TopologyHotspot(
             param, intersite_distance, num_clusters,
         )
+
+    def test_calculate_coordinates(self):
+        # algorithms for hexagonal coordinate systems (axial and cube)
+        # based on https://www.redblobgames.com/grids/hexagons/
+        def cube_round(q, r, s):
+            qr, rr, sr = np.round(q), np.round(r), np.round(s)
+            q_diff = np.abs(qr - q)
+            r_diff = np.abs(rr - r)
+            s_diff = np.abs(sr - s)
+
+            c1 = (q_diff > r_diff) & (q_diff > s_diff)
+            qr[c1] = -rr[c1] -sr[c1]
+
+            c2 = (r_diff > s_diff) &  (~c1)
+            rr[c2] = -qr[c2] -sr[c2]
+
+            c3 = (~c1) & (~c2)
+            sr[c3] = -qr[c3] -rr[c3]
+
+            return qr, rr, sr
+
+        def cube_to_axial(q, r, s):
+            return q, r
+        def axial_to_cube(q, r):
+            return q, r, -q -r
+
+        def axial_round(q, r):
+            return cube_to_axial(*cube_round(*axial_to_cube(q, r)))
+
+        def xy_to_axial(x, y, hex_radius):
+            """
+            Gets hexagon axial indice (q,r)
+                that contains (x,y) position
+            """
+            x += hex_radius
+
+            x, y = x / hex_radius, y / hex_radius
+            q = 2 * x / 3
+            r = -1 * x / 3 + np.sqrt(3) * y / 3
+
+            return axial_round(q, r)
+
+        n_hexagons = 19 * 3
+
+        rng = np.random.RandomState(11111)
+        param = ParametersHotspot()
+        param.num_hotspots_per_cell = 1
+        param.max_dist_hotspot_ue = 100
+        param.min_dist_hotspot_ue = 5
+        param.min_dist_bs_hotspot = 105
+
+        intersite_distance = 1000
+        num_clusters = 1
+        topology = TopologyHotspot(
+            param, intersite_distance, num_clusters,
+        )
+        topology.calculate_coordinates(rng)
+
+        expected_shp = (n_hexagons,)
+
+        self.assertEqual(topology.num_base_stations, expected_shp[0])
+        self.assertEqual(topology.x.shape, expected_shp)
+        self.assertEqual(topology.y.shape, expected_shp)
+        self.assertEqual(topology.z.shape, expected_shp)
+        self.assertEqual(topology.azimuth.shape, expected_shp)
+
+        hex_qr = xy_to_axial(
+            topology.x, topology.y, topology.intersite_distance / 3
+        )
+        count = Counter(zip(*hex_qr))
+        self.assertEqual(len(count), n_hexagons)
+        npt.assert_array_equal(list(count.values()), 1)
+
+
+        param.num_hotspots_per_cell = 3
+        topology = TopologyHotspot(
+            param, intersite_distance, num_clusters,
+        )
+        topology.calculate_coordinates(rng)
+
+        expected_shp = (n_hexagons * 3,)
+
+        self.assertEqual(topology.num_base_stations, expected_shp[0])
+        self.assertEqual(topology.x.shape, expected_shp)
+        self.assertEqual(topology.y.shape, expected_shp)
+        self.assertEqual(topology.z.shape, expected_shp)
+        self.assertEqual(topology.azimuth.shape, expected_shp)
+
+        hex_qr = xy_to_axial(
+            topology.x, topology.y, topology.intersite_distance / 3
+        )
+        count = Counter(zip(*hex_qr))
+
+        self.assertEqual(len(count), n_hexagons)
+        npt.assert_array_equal(list(count.values()), 3)
+
+
+        n_hexagons = 19 * 3 * 7
+        num_clusters = 7
+        topology = TopologyHotspot(
+            param, intersite_distance, num_clusters,
+        )
+        topology.calculate_coordinates(rng)
+
+        expected_shp = (n_hexagons * 3,)
+
+        self.assertEqual(topology.num_base_stations, expected_shp[0])
+        self.assertEqual(topology.x.shape, expected_shp)
+        self.assertEqual(topology.y.shape, expected_shp)
+        self.assertEqual(topology.z.shape, expected_shp)
+        self.assertEqual(topology.azimuth.shape, expected_shp)
+
+        hex_qr = xy_to_axial(
+            topology.x, topology.y, topology.intersite_distance / 3
+        )
+        count = Counter(zip(*hex_qr))
+        self.assertEqual(len(count), n_hexagons)
+        npt.assert_array_equal(list(count.values()), 3)
 
     def test_overlapping_hotspots(self):
         candidate_x = np.array([300])


### PR DESCRIPTION
Solves #169 

This fixes runtime error when trying to use hotspot topology.

New tests were added so that this may not happen again. The tests also check that the right amount of hotspots are in each hexagon.