### PR TITLE
feat: sqrt distance distribution for UE

### DIFF
--- a/sharc/station_factory.py
+++ b/sharc/station_factory.py
@@ -280,6 +280,15 @@ class StationFactory(object):
             elif param.ue.distribution_distance.upper() == "UNIFORM":
                 radius = (topology.cell_radius - param.minimum_separation_distance_bs_ue) * \
                     random_number_gen.random_sample(num_ue) + param.minimum_separation_distance_bs_ue
+            elif param.ue.distribution_distance.upper() == "SQRT(UNIFORM)":
+                # this is so that area distribution may be uniform in annulus/ring
+                r_min = param.minimum_separation_distance_bs_ue
+                r_max = topology.cell_radius
+                radius = np.sqrt(
+                    random_number_gen.random_sample(
+                        num_ue
+                    ) * (r_max**2 - r_min**2) + r_min**2
+                )
             else:
                 sys.stderr.write(
                     "ERROR\nInvalid UE distance distribution: " + param.ue.distribution_distance,


### PR DESCRIPTION
At some point some merge removed the SQRT(UNIFORM) for ue distance in angle_and_distance distribution type.

Added again the SQRT(UNIFORM) distribution, so that when combined with uniform azimuth it results in uniform area distribution for UEs.

The added complexity from the first PR (https://github.com/Radio-Spectrum/SHARC/pull/133/files) comes because this formula should also work for annulus. Demonstration can be done as in https://math.stackexchange.com/questions/2530527/how-to-generate-a-uniformly-distributed-point-in-an-annular-area
