### PR TITLE
fix: gdf shape files read are converted to spherical lat lon

### DIFF
--- a/sharc/parameters/imt/parameters_imt_mss_dc.py
+++ b/sharc/parameters/imt/parameters_imt_mss_dc.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import geopandas as gpd
 import shapely as shp
 
-from sharc.support.sharc_utils import load_epsg4326_gdf
+from sharc.support.sharc_utils import load_gdf
 from sharc.support.sharc_geom import shrink_countries_by_km, generate_grid_in_multipolygon
 from sharc.satellite.utils.sat_utils import lla2ecef
 from sharc.parameters.parameters_base import ParametersBase
@@ -149,7 +149,7 @@ class ParametersSectorPositioning(ParametersBase):
             """
             if self.lon_lat_grid is not None and not force_update:
                 return
-            filtered_gdf = load_epsg4326_gdf(
+            filtered_gdf = load_gdf(
                 self.country_shapes_filename,
                 {
                     "NAME": self.country_names
@@ -254,7 +254,7 @@ class ParametersSelectActiveSatellite(ParametersBase):
             if self.filter_polygon is not None and not force_update:
                 return
 
-            filtered_gdf = load_epsg4326_gdf(
+            filtered_gdf = load_gdf(
                 self.country_shapes_filename,
                 {
                     "NAME": self.country_names

--- a/sharc/satellite/ngso/constants.py
+++ b/sharc/satellite/ngso/constants.py
@@ -5,3 +5,10 @@ EARTH_RADIUS_M = 6378145  # radius of the Earth, in m
 EARTH_RADIUS_KM = 6378.145  # radius of the Earth, in km
 KEPLER_CONST = 398601.8  # Kepler's constant, in km^3/s^2
 EARTH_ROTATION_RATE = 2 * np.pi / (24 * 3600)  # earth's average rotation rate, in rad/s
+EARTH_SPHERICAL_CRS = f"+proj=longlat +a={EARTH_RADIUS_M} +b={EARTH_RADIUS_M} +no_defs"
+EARTH_DEFAULT_CRS = EARTH_SPHERICAL_CRS
+
+# EARTH_DEFAULT_CRS = "EPSG:4326"
+# # NOTE: This is no source of truth, but if you wish for non spherical earth,
+# # the functions lla2ecef and ecef2lla should also be changed
+# # More functionality may also need to be changed as the simulator grows

--- a/sharc/support/sharc_utils.py
+++ b/sharc/support/sharc_utils.py
@@ -3,6 +3,8 @@ import typing
 from pathlib import Path
 import geopandas as gpd
 
+from sharc.satellite.ngso.constants import EARTH_DEFAULT_CRS
+
 
 def is_float(s: str) -> bool:
     """Check if string represents a float value
@@ -30,14 +32,15 @@ def to_scalar(x):
     return x
 
 
-def load_epsg4326_gdf(
+def load_gdf(
     country_shapes_filename: typing.Union[Path, str],
     filters: dict[str, list[str]],
-    err_ctx: str = "load_epsg4326_gdf",
+    err_ctx: str = "load_gdf",
 ) -> gpd.GeoDataFrame:
     """
-    It is assumed that the shapefile has a name column, and that it is in EPSG:4326
+    It is assumed that the shapefile is in EPSG:4326
         containing polygons specified by (lon, lat) points
+        and the results are returned considering the default earth used
     Parameters:
         country_shapes_filename: path to shapefile to be read
         country_names: list of names to filter by and return
@@ -81,4 +84,4 @@ def load_epsg4326_gdf(
 
         filtered_gdf = filtered_gdf[filtered_gdf[filter_name].isin(filter_vals)]
 
-    return filtered_gdf
+    return filtered_gdf.to_crs(EARTH_DEFAULT_CRS)

--- a/sharc/topology/topology_imt_mss_dc.py
+++ b/sharc/topology/topology_imt_mss_dc.py
@@ -25,6 +25,7 @@ from sharc.support.sharc_geom import GeometryConverter, rotate_angles_based_on_n
 from sharc.topology.topology_ntn import TopologyNTN
 from sharc.satellite.utils.sat_utils import calc_elevation
 from sharc.support.sharc_geom import lla2ecef, cartesian_to_polar, polar_to_cartesian
+from sharc.satellite.ngso.constants import EARTH_DEFAULT_CRS
 
 
 class TopologyImtMssDc(Topology):
@@ -194,7 +195,7 @@ class TopologyImtMssDc(Topology):
                     flat_active_lat = pos_vec["lat"].flatten()[active_sats_mask]
 
                     # create points(lon, lat) to compare to country
-                    sats_points = gpd.points_from_xy(flat_active_lon, flat_active_lat, crs="EPSG:4326")
+                    sats_points = gpd.points_from_xy(flat_active_lon, flat_active_lat, crs=EARTH_DEFAULT_CRS)
 
                     # Check if the satellite is inside the country polygon
                     polygon_mask = np.zeros_like(active_sats_mask)
@@ -354,7 +355,7 @@ class TopologyImtMssDc(Topology):
             eligible_sats_msk = np.ones_like(all_sat_lat, dtype=bool)
 
             # create points(lon, lat) to compare to country
-            sats_points = gpd.points_from_xy(all_sat_lon[eligible_sats_msk], all_sat_lat[eligible_sats_msk], crs="EPSG:4326")
+            sats_points = gpd.points_from_xy(all_sat_lon[eligible_sats_msk], all_sat_lat[eligible_sats_msk], crs=EARTH_DEFAULT_CRS)
 
             # Check if the satellite is inside the country polygon
             polygon_mask = np.zeros_like(eligible_sats_msk, dtype=bool)

--- a/tests/parameters/test_parameters.py
+++ b/tests/parameters/test_parameters.py
@@ -4,6 +4,7 @@ from sharc.parameters.parameters import Parameters
 import numpy as np
 from contextlib import contextmanager
 from pyproj import Geod
+from sharc.satellite.ngso.constants import EARTH_RADIUS_M
 
 
 @contextmanager
@@ -688,7 +689,7 @@ class ParametersTest(unittest.TestCase):
         self.parameters.mss_d2d.sat_is_active_if.lat_long_inside_country.reset_filter_polygon("test", True)
         pol = self.parameters.mss_d2d.sat_is_active_if.lat_long_inside_country.filter_polygon
 
-        geod = Geod(ellps="WGS84")
+        geod = Geod(a=EARTH_RADIUS_M, b=EARTH_RADIUS_M)
 
         # this value was taken experimentally from the current implementation
         # and is not much different from census's results of 8.509.379,576 km^2
@@ -696,7 +697,7 @@ class ParametersTest(unittest.TestCase):
         BR_AREA = 8508557e6
         geod_area = abs(geod.geometry_area_perimeter(pol)[0])
 
-        self.assertAlmostEqual(geod_area, BR_AREA, delta=50e6)
+        self.assertAlmostEqual(geod_area, BR_AREA, delta=52e9)
 
         # test chile's area
         self.parameters.mss_d2d.sat_is_active_if.lat_long_inside_country.country_names = ["Chile"]
@@ -708,7 +709,7 @@ class ParametersTest(unittest.TestCase):
         CL_AREA = 814844e6
         geod_area = abs(geod.geometry_area_perimeter(pol)[0])
 
-        self.assertAlmostEqual(geod_area, CL_AREA, delta=50e6)
+        self.assertAlmostEqual(geod_area, CL_AREA, delta=2e9)
 
         # test area union
         self.parameters.mss_d2d.sat_is_active_if.lat_long_inside_country.country_names = ["Chile", "Brazil"]
@@ -717,7 +718,7 @@ class ParametersTest(unittest.TestCase):
 
         geod_area = abs(geod.geometry_area_perimeter(pol)[0])
         # this value was taken experimentally from the current implementation
-        self.assertAlmostEqual(geod_area / 1e6, (CL_AREA + BR_AREA) / 1e6, delta=50)
+        self.assertAlmostEqual(geod_area / 1e6, (CL_AREA + BR_AREA) / 1e6, delta=53e3)
 
 
 if __name__ == '__main__':

--- a/tests/test_sharc_geom.py
+++ b/tests/test_sharc_geom.py
@@ -5,7 +5,7 @@ import shapely as shp
 from pathlib import Path
 
 from sharc.support.sharc_geom import generate_grid_in_multipolygon
-from sharc.support.sharc_utils import load_epsg4326_gdf
+from sharc.support.sharc_utils import load_gdf
 
 
 class TestSharcGeom(unittest.TestCase):
@@ -47,7 +47,7 @@ class TestSharcGeom(unittest.TestCase):
             grid = generate_grid_in_multipolygon(poly, hx_r)
             npt.assert_allclose(len(grid[0]), pol_A / hx_A, rtol=0.05, atol=10)
 
-        gdf = load_epsg4326_gdf(
+        gdf = load_gdf(
             self.countries_shapefile,
             {"NAME": ["Brazil", "Chile"]}
         )
@@ -60,7 +60,7 @@ class TestSharcGeom(unittest.TestCase):
         hx_A = 3 * np.sqrt(3) * hx_r**2 / 2
 
         br_grid_len = len(grid[0])
-        npt.assert_allclose(br_grid_len, pol_A / hx_A, rtol=1e-5, atol=10)
+        npt.assert_allclose(br_grid_len, pol_A / hx_A, rtol=1e-5, atol=190)
 
         poly = gdf[gdf["NAME"] == "Chile"]["geometry"].values[0]
 


### PR DESCRIPTION
Relates to #171 

Shapefiles read were maintained in ther geodetic lat, lon. Now those values are converted to the `default_earth_crs` as soon as the file is read and filtered.

The tests were changed due to imprecision associated with this kind of modelling