### PR TITLE
Added, as requested in issue #162, a simulator log

### DIFF
--- a/sharc/main_cli.py
+++ b/sharc/main_cli.py
@@ -5,14 +5,16 @@ Created on Fri Aug 11 13:17:14 2017
 @author: edgar
 """
 
-from sharc.support.sharc_logger import Logging
-from sharc.support.sharc_logger import SimulationLogger
+import os
+import sys
+import getopt
+
+from sharc.support.sharc_logger import Logging, SimulationLogger
 from sharc.controller import Controller
 from sharc.gui.view_cli import ViewCli
 from sharc.model import Model
-import sys
-import getopt
-import os
+
+
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
 
@@ -22,7 +24,7 @@ def main(argv):
     param_file = ''
 
     try:
-        opts, args = getopt.getopt(argv, "hp:")
+        opts, _ = getopt.getopt(argv, "hp:")
     except getopt.GetoptError:
         print("usage: main_cli.py -p <param_file>")
         sys.exit(2)
@@ -35,7 +37,7 @@ def main(argv):
                 print("usage: main_cli.py -p <param_file>")
                 sys.exit()
             elif opt == "-p":
-                param_file = param_file = os.path.join(os.getcwd(), arg)
+                param_file = os.path.join(os.getcwd(), arg)
 
     sim_logger = SimulationLogger(param_file)
     sim_logger.start()

--- a/sharc/main_cli.py
+++ b/sharc/main_cli.py
@@ -6,6 +6,7 @@ Created on Fri Aug 11 13:17:14 2017
 """
 
 from sharc.support.sharc_logger import Logging
+from sharc.support.sharc_logger import SimulationLogger
 from sharc.controller import Controller
 from sharc.gui.view_cli import ViewCli
 from sharc.model import Model
@@ -36,6 +37,10 @@ def main(argv):
             elif opt == "-p":
                 param_file = param_file = os.path.join(os.getcwd(), arg)
 
+    output_dir = os.path.dirname(param_file)
+    sim_logger = SimulationLogger(output_dir)
+    sim_logger.start()
+
     Logging.setup_logging()
 
     model = Model()
@@ -46,7 +51,10 @@ def main(argv):
     controller.set_model(model)
     model.add_observer(view_cli)
 
-    view_cli.initialize(param_file)
+    try:
+        view_cli.initialize(param_file)
+    finally:
+        sim_logger.end()
 
 
 if __name__ == "__main__":

--- a/sharc/main_cli.py
+++ b/sharc/main_cli.py
@@ -10,11 +10,11 @@ from sharc.support.sharc_logger import SimulationLogger
 from sharc.controller import Controller
 from sharc.gui.view_cli import ViewCli
 from sharc.model import Model
+from pathlib import Path
 import sys
 import getopt
 import os
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
-
 
 def main(argv):
     print("Welcome to SHARC!\n")
@@ -37,8 +37,7 @@ def main(argv):
             elif opt == "-p":
                 param_file = param_file = os.path.join(os.getcwd(), arg)
 
-    output_dir = os.path.dirname(param_file)
-    sim_logger = SimulationLogger(output_dir)
+    sim_logger = SimulationLogger(param_file)
     sim_logger.start()
 
     Logging.setup_logging()

--- a/sharc/main_cli.py
+++ b/sharc/main_cli.py
@@ -10,11 +10,11 @@ from sharc.support.sharc_logger import SimulationLogger
 from sharc.controller import Controller
 from sharc.gui.view_cli import ViewCli
 from sharc.model import Model
-from pathlib import Path
 import sys
 import getopt
 import os
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
 
 def main(argv):
     print("Welcome to SHARC!\n")

--- a/sharc/main_cli.py
+++ b/sharc/main_cli.py
@@ -39,6 +39,7 @@ def main(argv):
             elif opt == "-p":
                 param_file = os.path.join(os.getcwd(), arg)
 
+    # Logger setup start
     sim_logger = SimulationLogger(param_file)
     sim_logger.start()
 

--- a/sharc/main_cli.py
+++ b/sharc/main_cli.py
@@ -21,7 +21,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 def main(argv):
     print("Welcome to SHARC!\n")
 
-    param_file = ''
+    param_file = ""
 
     try:
         opts, _ = getopt.getopt(argv, "hp:")

--- a/sharc/results.py
+++ b/sharc/results.py
@@ -132,7 +132,6 @@ class Results(object):
             self.output_directory = self.__sharc_dir / self.output_dir_parent
             try:
                 os.makedirs(self.output_directory)
-                            
             except FileExistsError:
                 pass
         SimulationLogger.set_output_dir(self.output_directory)
@@ -210,7 +209,7 @@ class Results(object):
         *,
         only_latest=True,
         only_samples: list[str] = None,
-        filter_fn=None
+        filter_fn=None,
     ) -> list["Results"]:
         output_dirs = list(glob.glob(f"{root_dir}/output_*"))
 
@@ -231,7 +230,9 @@ class Results(object):
 
         return all_res
 
-    def load_from_dir(self, abs_path: str, *, only_samples: list[str] = None) -> "Results":
+    def load_from_dir(
+        self, abs_path: str, *, only_samples: list[str] = None
+    ) -> "Results":
         self.output_directory = abs_path
 
         self_dict = self.__dict__

--- a/sharc/results.py
+++ b/sharc/results.py
@@ -11,7 +11,11 @@ import datetime
 import re
 import pathlib
 import pandas as pd
+import sys
+from pathlib import Path
 from shutil import copy
+from sharc.support.sharc_logger import SimulationLogger
+from typing import Optional
 
 
 class SampleList(list):
@@ -123,12 +127,15 @@ class Results(object):
             )
             self.create_dir(results_number, results_dir_head)
             copy(parameters_filename, self.output_directory)
+
         else:
             self.output_directory = self.__sharc_dir / self.output_dir_parent
             try:
                 os.makedirs(self.output_directory)
+                            
             except FileExistsError:
                 pass
+        SimulationLogger.SimulationSetDir().set_output_dir(self.output_directory)
 
         return self
 

--- a/sharc/results.py
+++ b/sharc/results.py
@@ -11,11 +11,8 @@ import datetime
 import re
 import pathlib
 import pandas as pd
-import sys
-from pathlib import Path
 from shutil import copy
 from sharc.support.sharc_logger import SimulationLogger
-from typing import Optional
 
 
 class SampleList(list):
@@ -231,8 +228,20 @@ class Results(object):
         return all_res
 
     def load_from_dir(
-        self, abs_path: str, *, only_samples: list[str] = None
-    ) -> "Results":
+            self,
+            abs_path: str,
+            *,
+            only_samples: list[str] = None) -> "Results":
+        """
+        Load results from a specified directory, optionally loading only specified samples.
+
+        Args:
+            abs_path (str): Absolute path to the output directory.
+            only_samples (list[str], optional): List of sample names to load. If None, load all samples. Defaults to None.
+
+        Returns:
+            Results: The Results object with loaded data.
+        """
         self.output_directory = abs_path
 
         self_dict = self.__dict__

--- a/sharc/results.py
+++ b/sharc/results.py
@@ -135,7 +135,7 @@ class Results(object):
                             
             except FileExistsError:
                 pass
-        SimulationLogger.SimulationSetDir().set_output_dir(self.output_directory)
+        SimulationLogger.set_output_dir(self.output_directory)
 
         return self
 

--- a/sharc/support/sharc_logger.py
+++ b/sharc/support/sharc_logger.py
@@ -38,17 +38,14 @@ class SimulationLogger:
         self.param_name = self.param_file.stem
         self.timestamp = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
 
-        # Pasta base da sessão (uma pasta por execução/sessão)
         self.session_dir = (
             self.param_file.parent.parent / "output" / log_base / self.timestamp
         )
         self.session_dir.mkdir(parents=True, exist_ok=True)
 
-        # Pasta para cada parâmetro dentro da sessão
         self.output_dir = self.session_dir / f"simulation_{self.param_name}_{self.timestamp}"
         self.output_dir.mkdir(parents=True, exist_ok=True)
 
-        # Arquivo YAML de log dentro da pasta específica
         self.log_path = self.output_dir / f"simulation_log_{self.timestamp}.yaml"
 
         self.start_time = None

--- a/sharc/support/sharc_logger.py
+++ b/sharc/support/sharc_logger.py
@@ -9,14 +9,20 @@ from datetime import datetime
 from typing import Optional
 
 
-class Logging:
+class Logging():
+
     @staticmethod
     def setup_logging(
-        default_path: str = 'support/logging.yaml',
-        default_level=logging.INFO,
-        env_key: str = 'LOG_CFG',
+        default_path='support/logging.yaml',
+        default_level=logging.INFO, env_key='LOG_CFG',
     ):
-        path = os.getenv(env_key, default_path)
+        """
+        Setup logging configuration
+        """
+        path = default_path
+        value = os.getenv(env_key, None)
+        if value:
+            path = value
         if os.path.exists(path):
             with open(path, 'rt') as f:
                 config = yaml.safe_load(f.read())

--- a/sharc/support/sharc_logger.py
+++ b/sharc/support/sharc_logger.py
@@ -7,8 +7,12 @@ Created on Mon Jan  9 18:15:47 2017
 
 import os
 import logging.config
-
 import yaml
+import subprocess
+import sys
+
+from datetime import datetime
+from pathlib import Path
 
 
 class Logging():
@@ -31,3 +35,63 @@ class Logging():
             logging.config.dictConfig(config)
         else:
             logging.basicConfig(level=default_level)
+
+
+class SimulationLogger:
+    def __init__(self, output_dir: str):
+        self.output_dir = Path(output_dir)
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        self.log_path = self.output_dir / f"simulation_output_log_{str(output_dir)}.yaml"
+        self.start_time = None
+        self.data = {
+            "repo": self._get_git_info(),
+            "run": {
+                "command": self._get_invocation_command(),
+                "python_version": self._get_python_version(),
+                "pkgs": self._get_installed_packages(),
+            }
+        }
+
+    def _run_git_cmd(self, args):
+        try:
+            return subprocess.check_output(['git'] + args, stderr=subprocess.DEVNULL).decode().strip()
+        except subprocess.CalledProcessError:
+            return None
+
+    def _get_git_info(self):
+        branch = self._run_git_cmd(['rev-parse', '--abbrev-ref', 'HEAD'])
+        commit = self._run_git_cmd(['rev-parse', 'HEAD'])
+        remote_name = self._run_git_cmd(['config', f'branch.{branch}.remote']) if branch else None
+        remote_url = self._run_git_cmd(['config', f'remote.{remote_name}.url']) if remote_name else None
+        return {
+            "url": remote_url or "N/A",
+            "branch": branch or "N/A",
+            "commit": commit or "N/A"
+        }
+
+    def _get_invocation_command(self):
+        return f"{sys.executable} {' '.join(sys.argv)}"
+
+    def _get_python_version(self):
+        return sys.version.replace("\n", " ")
+
+    def _get_installed_packages(self):
+        try:
+            pkgs = subprocess.check_output([sys.executable, '-m', 'pip', 'freeze'], stderr=subprocess.DEVNULL)
+            return sorted(pkgs.decode().strip().split('\n'))
+        except subprocess.CalledProcessError:
+            return ["Could not retrieve packages"]
+
+    def start(self):
+        self.start_time = datetime.now()
+        self.data["run"]["started_at"] = self.start_time.isoformat()
+
+    def end(self):
+        end_time = datetime.now()
+        self.data["run"]["ended_at"] = end_time.isoformat()
+        if self.start_time:
+            duration = end_time - self.start_time
+            self.data["run"]["duration"] = str(duration)
+
+        with open(self.log_path, "w") as f:
+            yaml.dump(self.data, f, sort_keys=False)

--- a/sharc/support/sharc_logger.py
+++ b/sharc/support/sharc_logger.py
@@ -9,12 +9,13 @@ from datetime import datetime
 from typing import Optional
 
 
-class Logging():
+class Logging:
 
     @staticmethod
     def setup_logging(
-        default_path='support/logging.yaml',
-        default_level=logging.INFO, env_key='LOG_CFG',
+        default_path="support/logging.yaml",
+        default_level=logging.INFO,
+        env_key="LOG_CFG",
     ):
         """
         Setup logging configuration
@@ -24,7 +25,7 @@ class Logging():
         if value:
             path = value
         if os.path.exists(path):
-            with open(path, 'rt') as f:
+            with open(path, "rt") as f:
                 config = yaml.safe_load(f.read())
             logging.config.dictConfig(config)
         else:
@@ -102,14 +103,20 @@ class SimulationLogger:
 
     def _run_git_cmd(self, args: list[str]) -> Optional[str]:
         try:
-            return subprocess.check_output(["git"] + args, stderr=subprocess.DEVNULL).decode().strip()
+            return (
+                subprocess.check_output(["git"] + args, stderr=subprocess.DEVNULL)
+                .decode()
+                .strip()
+            )
         except subprocess.CalledProcessError:
             return None
 
     def _get_git_info(self) -> dict:
         branch = self._run_git_cmd(["rev-parse", "--abbrev-ref", "HEAD"])
         commit = self._run_git_cmd(["rev-parse", "HEAD"])
-        remote = self._run_git_cmd(["config", f"branch.{branch}.remote"]) if branch else None
+        remote = (
+            self._run_git_cmd(["config", f"branch.{branch}.remote"]) if branch else None
+        )
         url = self._run_git_cmd(["config", f"remote.{remote}.url"]) if remote else None
 
         return {

--- a/sharc/support/sharc_logger.py
+++ b/sharc/support/sharc_logger.py
@@ -9,20 +9,14 @@ from datetime import datetime
 from typing import Optional
 
 
-class Logging():
-
+class Logging:
     @staticmethod
     def setup_logging(
         default_path='support/logging.yaml',
-        default_level=logging.INFO, env_key='LOG_CFG',
+        default_level=logging.INFO,
+        env_key='LOG_CFG',
     ):
-        """
-        Setup logging configuration
-        """
-        path = default_path
-        value = os.getenv(env_key, None)
-        if value:
-            path = value
+        path = os.getenv(env_key, default_path)
         if os.path.exists(path):
             with open(path, 'rt') as f:
                 config = yaml.safe_load(f.read())
@@ -38,7 +32,10 @@ class SimulationLogger:
         self.timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
 
         self.output_dir = (
-            self.param_file.parent.parent / "output" / log_base / f"simulation_{self.param_name}_{self.timestamp}"
+            self.param_file.parent.parent
+            / "output"
+            / log_base
+            / f"simulation_{self.param_name}_{self.timestamp}"
         )
         self.output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -53,7 +50,7 @@ class SimulationLogger:
                 "command": self._get_invocation_command(),
                 "python_version": self._get_python_version(),
                 "pkgs": self._get_installed_packages(),
-            }
+            },
         }
 
     def start(self):
@@ -78,19 +75,29 @@ class SimulationLogger:
 
     def _run_git_cmd(self, args: list[str]) -> Optional[str]:
         try:
-            return subprocess.check_output(['git'] + args, stderr=subprocess.DEVNULL).decode().strip()
+            return subprocess.check_output(
+                ['git'] + args, stderr=subprocess.DEVNULL
+            ).decode().strip()
         except subprocess.CalledProcessError:
             return None
 
     def _get_git_info(self) -> dict:
         branch = self._run_git_cmd(['rev-parse', '--abbrev-ref', 'HEAD'])
         commit = self._run_git_cmd(['rev-parse', 'HEAD'])
-        remote_name = self._run_git_cmd(['config', f'branch.{branch}.remote']) if branch else None
-        remote_url = self._run_git_cmd(['config', f'remote.{remote_name}.url']) if remote_name else None
+        remote_name = (
+            self._run_git_cmd(['config', f'branch.{branch}.remote'])
+            if branch
+            else None
+        )
+        remote_url = (
+            self._run_git_cmd(['config', f'remote.{remote_name}.url'])
+            if remote_name
+            else None
+        )
         return {
             "url": remote_url or "N/A",
             "branch": branch or "N/A",
-            "commit": commit or "N/A"
+            "commit": commit or "N/A",
         }
 
     def _get_invocation_command(self) -> str:
@@ -103,7 +110,7 @@ class SimulationLogger:
         try:
             pkgs = subprocess.check_output(
                 [sys.executable, '-m', 'pip', 'freeze'],
-                stderr=subprocess.DEVNULL
+                stderr=subprocess.DEVNULL,
             )
             return sorted(pkgs.decode().strip().split('\n'))
         except subprocess.CalledProcessError:

--- a/sharc/support/sharc_logger.py
+++ b/sharc/support/sharc_logger.py
@@ -43,10 +43,12 @@ class SimulationLogger:
 
     @classmethod
     def set_output_dir(cls, path: Path):
+        """Set the global output directory for simulation logs."""
         cls._global_output_dir = path.resolve()
 
     @classmethod
     def get_output_dir(cls) -> Optional[Path]:
+        """Return the global output directory, if set."""
         return cls._global_output_dir
 
     def __init__(self, param_file: str, log_base: str = "simulation_log"):

--- a/sharc/support/sharc_logger.py
+++ b/sharc/support/sharc_logger.py
@@ -9,17 +9,20 @@ from datetime import datetime
 from typing import Optional
 
 
-class Logging:
+class Logging():
+
     @staticmethod
     def setup_logging(
         default_path='support/logging.yaml',
-        default_level=logging.INFO,
-        env_key='LOG_CFG',
+        default_level=logging.INFO, env_key='LOG_CFG',
     ):
         """
-        Setup logging configuration.
+        Setup logging configuration
         """
-        path = os.getenv(env_key, default_path)
+        path = default_path
+        value = os.getenv(env_key, None)
+        if value:
+            path = value
         if os.path.exists(path):
             with open(path, 'rt') as f:
                 config = yaml.safe_load(f.read())

--- a/sharc/support/sharc_logger.py
+++ b/sharc/support/sharc_logger.py
@@ -10,6 +10,7 @@ from typing import Optional
 
 
 class Logging:
+    """Logging utility class for configuring application logging."""
 
     @staticmethod
     def setup_logging(

--- a/sharc/support/sharc_logger.py
+++ b/sharc/support/sharc_logger.py
@@ -16,6 +16,9 @@ class Logging:
         default_level=logging.INFO,
         env_key='LOG_CFG',
     ):
+        """
+        Setup logging configuration.
+        """
         path = os.getenv(env_key, default_path)
         if os.path.exists(path):
             with open(path, 'rt') as f:
@@ -26,7 +29,18 @@ class Logging:
 
 
 class SimulationLogger:
+    """
+    Logs simulation metadata to a YAML file for reproducibility.
+    """
+
     def __init__(self, param_file: str, log_base: str = "simulation_log"):
+        """
+        Initialize the logger with the parameter file path.
+
+        Args:
+            param_file (str): Path to the simulation parameter file.
+            log_base (str): Subdirectory for storing logs (default: 'simulation_log').
+        """
         self.param_file = Path(param_file).resolve()
         self.param_name = self.param_file.stem
         self.timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
@@ -54,10 +68,16 @@ class SimulationLogger:
         }
 
     def start(self):
+        """
+        Start the simulation timer and record initial metadata.
+        """
         self.start_time = datetime.now()
         self.data["run"]["started_at"] = self.start_time.isoformat()
 
     def end(self):
+        """
+        Stop the simulation timer, compute duration, and save the YAML log.
+        """
         end_time = datetime.now()
         self.data["run"]["ended_at"] = end_time.isoformat()
         if self.start_time:

--- a/sharc/support/sharc_logger.py
+++ b/sharc/support/sharc_logger.py
@@ -34,26 +34,23 @@ class SimulationLogger:
     """
 
     def __init__(self, param_file: str, log_base: str = "simulation_log"):
-        """
-        Initialize the logger with the parameter file path.
-
-        Args:
-            param_file (str): Path to the simulation parameter file.
-            log_base (str): Subdirectory for storing logs (default: 'simulation_log').
-        """
         self.param_file = Path(param_file).resolve()
         self.param_name = self.param_file.stem
-        self.timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+        self.timestamp = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
 
-        self.output_dir = (
-            self.param_file.parent.parent
-            / "output"
-            / log_base
-            / f"simulation_{self.param_name}_{self.timestamp}"
+        # Pasta base da sessão (uma pasta por execução/sessão)
+        self.session_dir = (
+            self.param_file.parent.parent / "output" / log_base / self.timestamp
         )
+        self.session_dir.mkdir(parents=True, exist_ok=True)
+
+        # Pasta para cada parâmetro dentro da sessão
+        self.output_dir = self.session_dir / f"simulation_{self.param_name}_{self.timestamp}"
         self.output_dir.mkdir(parents=True, exist_ok=True)
 
+        # Arquivo YAML de log dentro da pasta específica
         self.log_path = self.output_dir / f"simulation_log_{self.timestamp}.yaml"
+
         self.start_time = None
         self.root_dir = self._get_root_dir()
 


### PR DESCRIPTION
closes #162 

Added a `simulator log` as requested in **issue** #162;  an example of new feature bellow:
``` yaml
repo:
  url: git@github.com:Radio-Spectrum/SHARC.git
  branch: development
  commit: 1a3aec266295ba7e757b4608ec742bffa3330fd3
run:
  command: /Users/.../.venv/bin/python/.../sharc/support/sharc_logger.py
  python_version: 3.12.2 | packaged by conda-forge | (main, Feb 16 2024, 21:00:12)
    [Clang 16.0.6 ]
  pkgs:
  - -e git+https://github.com/Radio-Spectrum/SHARC@1a3aec266295ba7e757b4608ec742bffa3330fd3#egg=sharc
  - PyYAML==6.0.1
  - Pygments==2.18.0
  - appnope==0.1.4
  - area==1.1.1
  - asttokens==2.4.1
  - attrs==23.2.0
  - certifi==2024.7.4
  - click==8.1.7
  - colorama==0.4.6
  - comm==0.2.2
  - contourpy==1.2.0
  - cycler==0.12.1
  - debugpy==1.8.2
  - decorator==5.1.1
  - executing==2.0.1
  - fastjsonschema==2.20.0
  - fonttools==4.49.0
  - geopandas==1.0.1
  - ipykernel==6.29.5
  - ipython==8.26.0
  - jedi==0.19.1
  - jsonschema-specifications==2023.12.1
  - jsonschema==4.23.0
  - jupyter_client==8.6.2
  - jupyter_core==5.7.2
  - kaleido==0.2.1
  - kiwisolver==1.4.5
  - matplotlib-inline==0.1.7
  - matplotlib==3.8.3
  - multipledispatch==1.0.0
  - nbformat==5.10.4
  - nest-asyncio==1.6.0
  - numpy==1.26.4
  - packaging==23.2
  - pandas==2.2.2
  - parso==0.8.4
  - pexpect==4.9.0
  - pillow==10.2.0
  - platformdirs==4.2.2
  - plotly==5.23.0
  - prompt_toolkit==3.0.47
  - psutil==6.0.0
  - ptyprocess==0.7.0
  - pure_eval==0.2.3
  - pyaml==23.12.0
  - pyogrio==0.9.0
  - pyparsing==3.1.1
  - pyproj==3.6.1
  - python-dateutil==2.9.0.post0
  - pytz==2024.1
  - pyzmq==26.0.3
  - referencing==0.35.1
  - rpds-py==0.19.1
  - scipy==1.12.0
  - shapely==2.0.3
  - six==1.16.0
  - stack-data==0.6.3
  - tenacity==9.0.0
  - tornado==6.4.1
  - traitlets==5.14.3
  - tzdata==2024.1
  - wcwidth==0.2.13
  started_at: '2025-06-29T17:40:01.200155'
  ended_at: '2025-06-29T17:40:03.202616'
  duration: '0:00:02.002461'
  ```