### PR TITLE
Hotfix/supress divide by zero warnings

### DIFF
--- a/sharc/simulation_downlink.py
+++ b/sharc/simulation_downlink.py
@@ -233,11 +233,17 @@ class SimulationDownlink(Simulation):
                 if self.overlapping_bandwidth > 0:
                     # in_band_interf_power = self.param_system.tx_power_density + \
                     #     10 * np.log10(self.overlapping_bandwidth * 1e6) + 30
-                    in_band_interf_power = \
-                        self.param_system.tx_power_density + 10 * np.log10(
-                            self.ue.bandwidth[ue, np.newaxis] * 1e6
-                        ) + 10 * np.log10(weights)[:, np.newaxis] - \
-                        self.coupling_loss_imt_system[ue, :][:, active_sys]
+                    with warnings.catch_warnings():
+                        warnings.filterwarnings(
+                            "ignore",
+                            category=RuntimeWarning,
+                            message="divide by zero encountered in log10",
+                        )
+                        in_band_interf_power = \
+                            self.param_system.tx_power_density + 10 * np.log10(
+                                self.ue.bandwidth[ue, np.newaxis] * 1e6
+                            ) + 10 * np.log10(weights)[:, np.newaxis] - \
+                            self.coupling_loss_imt_system[ue, :][:, active_sys]
 
             oob_power = np.resize(-500., (len(ue), 1))
             if self.adjacent_channel:


### PR DESCRIPTION
This fix suppresses the huge amout of "divide by zero" warnings when co-channel is enabled and there are victim UEs with no overlapping bandwidth.