### PR TITLE
fix: spectral mask always receives dBm values

### DIFF
--- a/sharc/mask/spectral_mask_mss.py
+++ b/sharc/mask/spectral_mask_mss.py
@@ -79,12 +79,12 @@ class SpectralMaskMSS(SpectralMask):
         Set the spectral mask (mask_dbm attribute) based on station type, operating frequency and transmit power.
 
         Parameters:
-            p_tx (float): station transmit power.
+            p_tx (float): station transmit power in dBm
         """
         # dBm/MHz
         # this should work for the document's dBsd definition
         # when we have a uniform PSD in assigned band
-        self.p_tx = p_tx - 10 * np.log10(self.band_mhz) + 30
+        self.p_tx = p_tx - 10 * np.log10(self.band_mhz)
 
         # attenuation mask
         mask_dbsd = 40 * np.log10(

--- a/sharc/station_factory.py
+++ b/sharc/station_factory.py
@@ -1249,7 +1249,9 @@ class StationFactory(object):
             else:
                 raise ValueError(f"Invalid or not implemented spectral mask - {param.spectral_mask}")
 
-            single_earth_station.spectral_mask.set_mask(param.tx_power_density + 10 * np.log10(param.bandwidth * 1e6))
+            single_earth_station.spectral_mask.set_mask(
+                param.tx_power_density + 10 * np.log10(param.bandwidth * 1e6) + 30
+            )
 
         return single_earth_station
 
@@ -1632,7 +1634,8 @@ class StationFactory(object):
             10 *
             np.log10(
                 param_mss.bandwidth *
-                1e6))
+                1e6) + 30
+        )
 
         return mss_ss
 
@@ -1697,7 +1700,8 @@ class StationFactory(object):
             10 *
             np.log10(
                 params.bandwidth *
-                1e6))
+                1e6) + 30
+        )
 
        # Configure satellite positions in the StationManager
         mss_d2d.x = mss_d2d_values["sat_x"]

--- a/tests/test_spectral_mask_mss.py
+++ b/tests/test_spectral_mask_mss.py
@@ -21,10 +21,10 @@ class SpectalMaskMSSTest(unittest.TestCase):
         p_tx_density = -30  # dBW / Hz
         freq = 2190
         band = 1
-        p_tx = p_tx_density + 10 * np.log10(band * 1e6)
+        p_tx = p_tx_density + 10 * np.log10(band * 1e6) + 30
 
         # reference bw is 4khz below 15GHz center freq
-        p_tx_over_4khz = p_tx_density + 10 * np.log10(4e3)
+        p_tx_over_4khz = p_tx_density + 10 * np.log10(4e3) + 30
 
         # dBm/MHz
         spurious_emissions = -30
@@ -45,7 +45,7 @@ class SpectalMaskMSSTest(unittest.TestCase):
 
             F = (f_offset - band / 2) / band * 100
 
-            should_eq[2 * i] = p_tx_over_4khz - 40 * np.log10(F / 50 + 1) + 30
+            should_eq[2 * i] = p_tx_over_4khz - 40 * np.log10(F / 50 + 1)
             eq[2 * i] = mask.power_calc(freq + f_offset + 0.5 * 4e-3, 4e-3)
 
             should_eq[2 * i + 1] = should_eq[2 * i]


### PR DESCRIPTION
When using spectral mask, IMT passed its power in dBm, system passed its power in dB.

Since new spectral mask, MSS, should be used by both IMT (topology MSS_DC) and system MSS_D2D, the units of the passed values needed to be the same