### PR TITLE
fix(antenna): Fixes nan values generated when angles were higher than

### DIFF
--- a/sharc/antenna/antenna_mss_adjacent.py
+++ b/sharc/antenna/antenna_mss_adjacent.py
@@ -43,9 +43,10 @@ class AntennaMSSAdjacent(Antenna):
         np.array
             Calculated antenna gain values.
         """
-        theta = np.absolute(kwargs["off_axis_angle_vec"])
+        theta_rad = np.deg2rad(np.absolute(kwargs["off_axis_angle_vec"]))
+        theta_rad = np.minimum(theta_rad, np.pi / 2 - 1e-4)
         return 20 * np.log10(self.frequency / 2e3) + 10 * \
-            np.log10(np.cos(np.deg2rad(theta)))
+            np.log10(np.cos(theta_rad))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The System 3 OOBE emissions mask has a cosine term that's implemented as an antenna pattern.

<img width="586" height="179" alt="image" src="https://github.com/user-attachments/assets/74d112df-a3e1-45d8-8418-338000daa82f" />

This is valid only for theta angles between the [0, 90[ degrees range.
This fix clips the `off_axis_angle` to be between that valid range. 