### PR TITLE
update: uses_beamforming antenna attribute

### DIFF
--- a/sharc/antenna/antenna.py
+++ b/sharc/antenna/antenna.py
@@ -21,6 +21,7 @@ class Antenna(ABC):
     def __init__(self):
         self.beams_list = []
         self.w_vec_list = []
+        self.uses_beamforming = False
 
     @abstractmethod
     def calculate_gain(self, *args, **kwargs) -> np.array:

--- a/sharc/antenna/antenna_beamforming_imt.py
+++ b/sharc/antenna/antenna_beamforming_imt.py
@@ -60,6 +60,7 @@ class AntennaBeamformingImt(Antenna):
                 referenced in the x axis
         """
         super().__init__()
+        self.uses_beamforming = True
         self.param = par
         self.subarray = None
 

--- a/sharc/simulation.py
+++ b/sharc/simulation.py
@@ -473,12 +473,13 @@ class Simulation(ABC, Observable):
         Select K UEs randomly from all the UEs linked to one BS as “chosen”
         UEs. These K “chosen” UEs will be scheduled during this snapshot.
         """
+        if not self.bs.antenna[0].uses_beamforming:
+            return
+
         if self.wrap_around_enabled:
             self.bs_to_ue_d_2D, self.bs_to_ue_d_3D, self.bs_to_ue_phi, self.bs_to_ue_theta = \
                 self.bs.get_dist_angles_wrap_around(self.ue)
         else:
-            self.bs_to_ue_d_2D = self.bs.get_distance_to(self.ue)
-            self.bs_to_ue_d_3D = self.bs.get_3d_distance_to(self.ue)
             self.bs_to_ue_phi, self.bs_to_ue_theta = self.bs.get_pointing_vector_to(
                 self.ue, )
 


### PR DESCRIPTION
## DONE:

The `select_ue` function does not live up to its name. It does not select ue's, it only creates the beamforming parameters. However, the current implementation is really slow for a big number of base stations, and it made the performance of simulations considerably worse.

For example, when using MSS DC as IMT, there can be a LOT of active satellites per drop since constellations are big. 1 example drop performance stats:
<img width="1328" height="421" alt="image" src="https://github.com/user-attachments/assets/e93e1ec5-5d70-49c4-86ec-32c13d6abbc4" />

Adding an attribute to completely skip adding beamforming vectors when they are not needed solves the current problem, since MSS DC considered does not use antenna array and doesn't do digital beamforming.

## TODO:

More testing is needed with different parameters use cases. Not sure the current implementation doesn't normal macrocell/hotspot simulations.