### PR TITLE
update(propagation): Changed P.2108 parameter type to clutter_scenario.

### DIFF
--- a/docs/docusaurus/docs/Systems/Earth Exploration Satellite Service.md
+++ b/docs/docusaurus/docs/Systems/Earth Exploration Satellite Service.md
@@ -11,7 +11,7 @@ sidebar_position: 1
 The **Earth Exploration Satellite Service** is a radiocommunication service that 
 employs satellites to gather environmetal data, facilitating analysis and monitoring 
 of the Earth's surface and atmosphere. The systme is essential in land-use studies, oceanography, 
-disaster and environmental management. The implemented spacial system is indispensable for research
+disaster and environmental management. The implemented spatial system is indispensable for research
 and management actities in atmospherical context.
 
 ### Overview

--- a/sharc/propagation/propagation_clear_air_452.py
+++ b/sharc/propagation/propagation_clear_air_452.py
@@ -1824,7 +1824,7 @@ class PropagationClearAir(Propagation):
             clutter_loss = self.clutter.get_loss(
                 frequency=frequency * 1000,
                 distance=distance * 1000,
-                station_type=StationType.FSS_ES,
+                clutter_scenario="terrestrial",  # Always terrestrial for P.452
                 clutter_type=self.model_params.clutter_type
             )
         else:

--- a/sharc/propagation/propagation_clutter_loss.py
+++ b/sharc/propagation/propagation_clutter_loss.py
@@ -62,7 +62,7 @@ class PropagationClutterLoss(Propagation):
             loc_percentage (np.array) : Percentage locations range [0, 1[
                                         "RANDOM" for random percentage (Default = RANDOM)
             clutter_scenario (str) : clutter scenario type:
-                                        "spacial" for Earth-space and aeronautical paths
+                                        "spatial" for Earth-space and aeronautical paths
                                         "terrestrial" for terrestrial paths
 
         Returns
@@ -99,22 +99,22 @@ class PropagationClutterLoss(Propagation):
                 loss = self.get_terrestrial_clutter_loss(f, d, p1, True) + self.get_terrestrial_clutter_loss(f, d, p2, False)
             else:
                 raise ValueError("Invalid type of Clutter-type. It can be either 'one_end' or 'both-ends'")
-        elif clutter_scenario == "spacial":
+        elif clutter_scenario == "spatial":
             theta = kwargs["elevation"]
             earth_station_height = kwargs["earth_station_height"]
             mean_clutter_height = kwargs["mean_clutter_height"]
             below_rooftop = kwargs["below_rooftop"]
-            loss = self.get_spacial_clutter_loss(f, theta, p1, earth_station_height, mean_clutter_height)
+            loss = self.get_spatial_clutter_loss(f, theta, p1, earth_station_height, mean_clutter_height)
             mult_1 = np.zeros(d.shape)
             num_ones = int(np.round(mult_1.size * below_rooftop / 100))
             indices = self.random_number_gen.choice(mult_1.size, size=num_ones, replace=False)
             mult_1.flat[indices] = 1
             loss *= mult_1
         else:
-            raise ValueError("Invalid type of Clutter-scenario. It can be either 'terrestrial' or 'spacial'")
+            raise ValueError("Invalid type of Clutter-scenario. It can be either 'terrestrial' or 'spatial'")
         return loss
 
-    def get_spacial_clutter_loss(
+    def get_spatial_clutter_loss(
         self, frequency: float,
         elevation_angle: float,
         loc_percentage,
@@ -330,7 +330,7 @@ if __name__ == '__main__':
     clutter_loss = np.empty([len(elevation_angle), len(loc_percentage)])
 
     for i in range(len(elevation_angle)):
-        clutter_loss[i, :] = cl.get_spacial_clutter_loss(
+        clutter_loss[i, :] = cl.get_spatial_clutter_loss(
             frequency,
             elevation_angle[i],
             loc_percentage,

--- a/sharc/propagation/propagation_clutter_loss.py
+++ b/sharc/propagation/propagation_clutter_loss.py
@@ -61,19 +61,24 @@ class PropagationClutterLoss(Propagation):
             elevation (np.array) : elevation angles [deg]
             loc_percentage (np.array) : Percentage locations range [0, 1[
                                         "RANDOM" for random percentage (Default = RANDOM)
-            station_type (StationType) : if type is IMT or FSS_ES, assume terrestrial
-                terminal within the clutter (ref § 3.2); otherwise, assume that
-                one terminal is within the clutter and the other is a satellite,
-                aeroplane or other platform above the surface of the Earth.
+            clutter_scenario (str) : clutter scenario type:
+                                        "spacial" for Earth-space and aeronautical paths
+                                        "terrestrial" for terrestrial paths
 
         Returns
         -------
             array with clutter loss values with dimensions of distance
 
         """
+        # Check for required parameters
+        required_params = ["frequency", "clutter_scenario", "distance"]
+        missing_params = [p for p in required_params if p not in kwargs]
+        if missing_params:
+            raise ValueError(f"Missing required parameter(s): {', '.join(missing_params)}")
+
         f = kwargs["frequency"]
         loc_per = kwargs.pop("loc_percentage", "RANDOM")
-        type = kwargs["station_type"]
+        clutter_scenario = kwargs["clutter_scenario"]
         d = kwargs["distance"]
 
         if f.size == 1:
@@ -86,7 +91,7 @@ class PropagationClutterLoss(Propagation):
             p1 = loc_per * np.ones(d.shape)
             p2 = loc_per * np.ones(d.shape)
 
-        if type is StationType.IMT_BS or type is StationType.IMT_UE or type is StationType.FSS_ES:
+        if clutter_scenario == "terrestrial":
             clutter_type = kwargs["clutter_type"]
             if clutter_type == 'one_end':
                 loss = self.get_terrestrial_clutter_loss(f, d, p1, True)
@@ -94,7 +99,7 @@ class PropagationClutterLoss(Propagation):
                 loss = self.get_terrestrial_clutter_loss(f, d, p1, True) + self.get_terrestrial_clutter_loss(f, d, p2, False)
             else:
                 raise ValueError("Invalid type of Clutter-type. It can be either 'one_end' or 'both-ends'")
-        else:
+        elif clutter_scenario == "spacial":
             theta = kwargs["elevation"]
             earth_station_height = kwargs["earth_station_height"]
             mean_clutter_height = kwargs["mean_clutter_height"]
@@ -105,6 +110,8 @@ class PropagationClutterLoss(Propagation):
             indices = self.random_number_gen.choice(mult_1.size, size=num_ones, replace=False)
             mult_1.flat[indices] = 1
             loss *= mult_1
+        else:
+            raise ValueError("Invalid type of Clutter-scenario. It can be either 'terrestrial' or 'spacial'")
         return loss
 
     def get_spacial_clutter_loss(

--- a/sharc/propagation/propagation_p619.py
+++ b/sharc/propagation/propagation_p619.py
@@ -486,7 +486,7 @@ class PropagationP619(Propagation):
                     frequency=frequency,
                     distance=distance,
                     elevation=elevation["free_space"],
-                    clutter_scenario="spacial",
+                    clutter_scenario="spatial",
                     earth_station_height=earth_station_height,
                     mean_clutter_height=self.mean_clutter_height,
                     below_rooftop=self.below_rooftop,

--- a/sharc/propagation/propagation_p619.py
+++ b/sharc/propagation/propagation_p619.py
@@ -486,7 +486,7 @@ class PropagationP619(Propagation):
                     frequency=frequency,
                     distance=distance,
                     elevation=elevation["free_space"],
-                    station_type=StationType.FSS_SS,
+                    clutter_scenario="spacial",
                     earth_station_height=earth_station_height,
                     mean_clutter_height=self.mean_clutter_height,
                     below_rooftop=self.below_rooftop,

--- a/tests/test_propagation_clutter.py
+++ b/tests/test_propagation_clutter.py
@@ -25,7 +25,7 @@ class TestPropagationClutterLoss(unittest.TestCase):
             frequency=frequency,
             elevation=elevation,
             loc_percentage=loc_percentage,
-            clutter_scenario="spacial",
+            clutter_scenario="spatial",
             earth_station_height=earth_station_height,
             mean_clutter_height=mean_clutter_height,
             below_rooftop=below_rooftop,

--- a/tests/test_propagation_clutter.py
+++ b/tests/test_propagation_clutter.py
@@ -25,7 +25,7 @@ class TestPropagationClutterLoss(unittest.TestCase):
             frequency=frequency,
             elevation=elevation,
             loc_percentage=loc_percentage,
-            station_type=StationType.FSS_SS,
+            clutter_scenario="spacial",
             earth_station_height=earth_station_height,
             mean_clutter_height=mean_clutter_height,
             below_rooftop=below_rooftop,
@@ -48,7 +48,7 @@ class TestPropagationClutterLoss(unittest.TestCase):
             frequency=frequency,
             distance=distance,
             loc_percentage=loc_percentage,
-            station_type=StationType.IMT_BS,
+            clutter_scenario="terrestrial",
             clutter_type=clutter_type
         )
 
@@ -65,7 +65,7 @@ class TestPropagationClutterLoss(unittest.TestCase):
             frequency=frequency,
             distance=distance,
             loc_percentage="RANDOM",
-            station_type=StationType.IMT_UE,
+            clutter_scenario="terrestrial",
             clutter_type=clutter_type
         )
 


### PR DESCRIPTION
The type parameter expects the StationType to check if the clutter scenario is terrestrial or spatial. This is prone to errors if the study is between IMT and another station that is not FSS_ES or FSS_SS.
Now the user specifies if it's a "terrestrial" path (P.2108 sec 3.2) or "spatial" path (P.2108 sec 3.3).

BRAKING CHANGE: That might break simulation campaigns that relied on the StationType parameter.