### PR TITLE
Fix/subsatellite distance

### DIFF
--- a/sharc/satellite/utils/sat_utils.py
+++ b/sharc/satellite/utils/sat_utils.py
@@ -133,9 +133,115 @@ def haversine(
     a = np.sin(dlat / 2)**2 + np.cos(lat1) * np.cos(lat2) * np.sin(dlon / 2)**2
     return 2 * R * np.arcsin(np.sqrt(a))
 
+def sat_elevation_to_offaxis(elevation_angle_deg: float | np.ndarray, sat_altitude_m: float | np.ndarray) -> float:
+    """
+    Convert satellite elevation angle to off-axis angle (angle from nadir).
+
+    Parameters
+    ----------
+    elevation_angle_deg : float
+        Elevation angle in degrees.
+    sat_altitude_m : float
+        Satellite altitude above Earth's surface in meters.
+
+    Returns
+    -------
+    float
+        Off-axis angle in degrees.
+    """
+    if np.isscalar(elevation_angle_deg):
+        if elevation_angle_deg < 0 or elevation_angle_deg > 90:
+            raise ValueError("Elevation angle must be between 0 and 90 degrees.")
+    else:
+        if (elevation_angle_deg < 0).any() or (elevation_angle_deg > 90).any():
+            raise ValueError("Elevation angle must be between 0 and 90 degrees.")
+
+    # Convert elevation angle to radians
+    elevation_angle_rad = np.deg2rad(elevation_angle_deg)
+
+    # Calculate the distance from the Earth's center to the satellite
+    r_sat = EARTH_RADIUS_M + sat_altitude_m
+
+    # Calculate the off-axis angle using the spherical triangle relationship
+    offaxis_angle_rad = np.arcsin(
+        (EARTH_RADIUS_M / r_sat) * np.sin(elevation_angle_rad + np.pi / 2)
+    )
+
+    # Convert off-axis angle back to degrees
+    offaxis_angle_deg = np.rad2deg(offaxis_angle_rad)
+
+    return offaxis_angle_deg
+
+def offaxis_to_sat_elevation(offaxis_angle_deg: float | np.ndarray, sat_altitude_m: float | np.ndarray) -> float:
+    """
+    Convert off-axis angle (angle from nadir) to satellite elevation angle.
+
+    Parameters
+    ----------
+    offaxis_angle_deg : float
+        Off-axis angle in degrees.
+    sat_altitude_km : float
+        Satellite altitude above Earth's surface in meters.
+
+    Returns
+    -------
+    float
+        Elevation angle in degrees.
+    """
+    # We know that 90 deg offaxis is physically impossible, so raise ValueError
+    if np.isscalar(offaxis_angle_deg):
+        if offaxis_angle_deg < 0 or offaxis_angle_deg >= 90:
+            raise ValueError("Elevation angle must be between 0 and 90 degrees.")
+    else:
+        if (offaxis_angle_deg < 0).any() or (offaxis_angle_deg >= 90).any():
+            raise ValueError("Elevation angle must be between 0 and 90 degrees.")
+    # Convert off-axis angle to radians
+    offaxis_angle_rad = np.deg2rad(offaxis_angle_deg)
+
+    # Calculate the distance from the Earth's center to the satellite
+    r_sat = EARTH_RADIUS_M + sat_altitude_m
+
+    # Calculate the elevation angle using the sine law.
+    elevation_angle_rad = np.pi / 2 - np.arcsin((r_sat) / EARTH_RADIUS_M * np.sin(offaxis_angle_rad))
+
+    # Convert elevation angle back to degrees
+    elevation_angle_deg = np.rad2deg(elevation_angle_rad)
+
+    return elevation_angle_deg
+
+def earth_arc_length_from_nadir(offaxis_angle_deg: float | np.ndarray, sat_altitude_m: float | np.ndarray) -> float:
+    """
+    Calculate the Earth's surface arc length from nadir to the point
+    corresponding to the given off-axis angle.
+
+    Parameters
+    ----------
+    offaxis_angle_deg : float
+        Off-axis angle in degrees.
+    sat_altitude_km : float
+        Satellite altitude above Earth's surface in meters.
+
+    Returns
+    -------
+    float
+        Arc length on Earth's surface in meters.
+    """
+    # Convert off-axis angle to radians
+    offaxis_angle_rad = np.deg2rad(offaxis_angle_deg)
+
+    phi_rad = np.deg2rad(offaxis_to_sat_elevation(offaxis_angle_deg, sat_altitude_m) + 90.0)
+
+    central_angle_rad = np.pi - phi_rad - offaxis_angle_rad
+
+    # Calculate the arc length on Earth's surface
+    arc_length_m = EARTH_RADIUS_M * central_angle_rad
+
+    return arc_length_m
 
 if __name__ == "__main__":
     r1 = ecef2lla(7792.1450, 0, 0)
     print(r1)
     r2 = lla2ecef(r1[0], r1[1], r1[2])
     print(r2)
+
+    print(earth_arc_length_from_nadir(np.array([0, 10, 30, 45, 60]), 520.0))

--- a/sharc/satellite/utils/sat_utils.py
+++ b/sharc/satellite/utils/sat_utils.py
@@ -133,6 +133,7 @@ def haversine(
     a = np.sin(dlat / 2)**2 + np.cos(lat1) * np.cos(lat2) * np.sin(dlon / 2)**2
     return 2 * R * np.arcsin(np.sqrt(a))
 
+
 def sat_elevation_to_offaxis(elevation_angle_deg: float | np.ndarray, sat_altitude_m: float | np.ndarray) -> float:
     """
     Convert satellite elevation angle to off-axis angle (angle from nadir).
@@ -172,6 +173,7 @@ def sat_elevation_to_offaxis(elevation_angle_deg: float | np.ndarray, sat_altitu
 
     return offaxis_angle_deg
 
+
 def offaxis_to_sat_elevation(offaxis_angle_deg: float | np.ndarray, sat_altitude_m: float | np.ndarray) -> float:
     """
     Convert off-axis angle (angle from nadir) to satellite elevation angle.
@@ -209,6 +211,7 @@ def offaxis_to_sat_elevation(offaxis_angle_deg: float | np.ndarray, sat_altitude
 
     return elevation_angle_deg
 
+
 def earth_arc_length_from_nadir(offaxis_angle_deg: float | np.ndarray, sat_altitude_m: float | np.ndarray) -> float:
     """
     Calculate the Earth's surface arc length from nadir to the point
@@ -238,10 +241,13 @@ def earth_arc_length_from_nadir(offaxis_angle_deg: float | np.ndarray, sat_altit
 
     return arc_length_m
 
+
 if __name__ == "__main__":
     r1 = ecef2lla(7792.1450, 0, 0)
     print(r1)
     r2 = lla2ecef(r1[0], r1[1], r1[2])
     print(r2)
 
-    print(earth_arc_length_from_nadir(np.array([0, 10, 30, 45, 60]), 520.0))
+    print(earth_arc_length_from_nadir(2.19, 520.0 * 1e3))
+
+    print(sat_elevation_to_offaxis(50.0, 520e3))

--- a/sharc/topology/topology_imt_mss_dc.py
+++ b/sharc/topology/topology_imt_mss_dc.py
@@ -23,7 +23,7 @@ from sharc.parameters.parameters_orbit import ParametersOrbit
 from sharc.satellite.ngso.orbit_model import OrbitModel
 from sharc.support.sharc_geom import CoordinateSystem, rotate_angles_based_on_new_nadir
 from sharc.topology.topology_ntn import TopologyNTN
-from sharc.satellite.utils.sat_utils import calc_elevation
+from sharc.satellite.utils.sat_utils import calc_elevation, earth_arc_length_from_nadir
 from sharc.support.sharc_geom import lla2ecef, cartesian_to_polar, polar_to_cartesian
 from sharc.satellite.ngso.constants import EARTH_DEFAULT_CRS
 
@@ -529,7 +529,11 @@ class TopologyImtMssDc(Topology):
                 raise ValueError(
                     f"mss_d2d_params.beam_positioning.angle_from_subsatellite_theta.type = \n" f"'{
                         orbit_params.beam_positioning.angle_from_subsatellite_theta.type}' is not recognized!")
-            subsatellite_distance_add = sat_altitude * np.tan(off_nadir_add)
+            # subsatellite_distance_add = sat_altitude * np.tan(np.deg2rad(off_nadir_add))
+            subsatellite_distance_add = earth_arc_length_from_nadir(
+                off_nadir_add,
+                sat_altitude
+            )
 
             azim_add = TopologyImtMssDc.get_distr(
                 random_number_gen,

--- a/sharc/topology/topology_imt_mss_dc.py
+++ b/sharc/topology/topology_imt_mss_dc.py
@@ -23,7 +23,7 @@ from sharc.parameters.parameters_orbit import ParametersOrbit
 from sharc.satellite.ngso.orbit_model import OrbitModel
 from sharc.support.sharc_geom import CoordinateSystem, rotate_angles_based_on_new_nadir
 from sharc.topology.topology_ntn import TopologyNTN
-from sharc.satellite.utils.sat_utils import calc_elevation, earth_arc_length_from_nadir
+from sharc.satellite.utils.sat_utils import calc_elevation
 from sharc.support.sharc_geom import lla2ecef, cartesian_to_polar, polar_to_cartesian
 from sharc.satellite.ngso.constants import EARTH_DEFAULT_CRS
 
@@ -529,11 +529,7 @@ class TopologyImtMssDc(Topology):
                 raise ValueError(
                     f"mss_d2d_params.beam_positioning.angle_from_subsatellite_theta.type = \n" f"'{
                         orbit_params.beam_positioning.angle_from_subsatellite_theta.type}' is not recognized!")
-            # subsatellite_distance_add = sat_altitude * np.tan(np.deg2rad(off_nadir_add))
-            subsatellite_distance_add = earth_arc_length_from_nadir(
-                off_nadir_add,
-                sat_altitude
-            )
+            subsatellite_distance_add = sat_altitude * np.tan(off_nadir_add)
 
             azim_add = TopologyImtMssDc.get_distr(
                 random_number_gen,

--- a/sharc/topology/topology_imt_mss_dc.py
+++ b/sharc/topology/topology_imt_mss_dc.py
@@ -529,7 +529,7 @@ class TopologyImtMssDc(Topology):
                 raise ValueError(
                     f"mss_d2d_params.beam_positioning.angle_from_subsatellite_theta.type = \n" f"'{
                         orbit_params.beam_positioning.angle_from_subsatellite_theta.type}' is not recognized!")
-            subsatellite_distance_add = sat_altitude * np.tan(off_nadir_add)
+            subsatellite_distance_add = sat_altitude * np.tan(np.deg2rad(off_nadir_add))
 
             azim_add = TopologyImtMssDc.get_distr(
                 random_number_gen,

--- a/tests/test_sat_utils.py
+++ b/tests/test_sat_utils.py
@@ -136,6 +136,50 @@ class TestSatUtils(unittest.TestCase):
             )
             npt.assert_almost_equal(e, expected_elevations[i], 1)
 
+    def test_sat_elevation_offaxis_conversion(self):
+        """Test conversion between satellite elevation angle and off-axis angle."""
+        sat_altitude_km = 520.0
+
+        test_elevation_angles = np.array([0.0, 10.0, 30.0, 45.0, 60.0, 80.0, 90.0])
+        for elev_angle in test_elevation_angles:
+            offaxis_angle = sat_utils.sat_elevation_to_offaxis(elev_angle, sat_altitude_km)
+            elev_angle_converted = sat_utils.offaxis_to_sat_elevation(offaxis_angle, sat_altitude_km)
+            npt.assert_almost_equal(elev_angle, elev_angle_converted, 5)
+
+    def test_sat_elevation_offaxis_conversion_raises_value_error(self):
+        """Test that ValueError is raised for invalid elevation angles."""
+        sat_altitude_km = 520.0
+
+        invalid_elevation_angles = [-10.0, 100.0, 150.0]
+        for elev_angle in invalid_elevation_angles:
+            with self.assertRaises(ValueError):
+                sat_utils.sat_elevation_to_offaxis(elev_angle, sat_altitude_km)
+
+        with self.assertRaises(ValueError):
+            sat_utils.sat_elevation_to_offaxis(np.array([10.0, -5.0, 30.0]), sat_altitude_km)
+
+    def test_offaxis_sat_elevation_conversion_raises_value_error(self):
+        """Test that ValueError is raised for invalid elevation angles in offaxis_to_sat_elevation."""
+        sat_altitude_km = 520.0
+
+        invalid_offaxis_angles = [-10.0, 100.0, 150.0]
+        for elev_angle in invalid_offaxis_angles:
+            with self.assertRaises(ValueError):
+                sat_utils.offaxis_to_sat_elevation(elev_angle, sat_altitude_km)
+
+        with self.assertRaises(ValueError):
+            sat_utils.offaxis_to_sat_elevation(np.array([10.0, -5.0, 30.0]), sat_altitude_km)
+
+    def test_earth_arc_length_from_nadir(self):
+        """Test calculation of Earth's arc length from nadir based on off-axis angle."""
+        sat_altitude_m = 520.0 * 1e3
+
+        test_offaxis_angles = np.array([0.0, 10.0, 30.0, 45.0, 60.0])
+        expected_arc_lengths_m = np.array([0, 91.80971067, 304.53451317, 543.82932797, 1056.78781731]) * 1e3
+
+        arc_length = sat_utils.earth_arc_length_from_nadir(test_offaxis_angles, sat_altitude_m)
+        npt.assert_almost_equal(arc_length, expected_arc_lengths_m, decimal=3)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR fixes an error in TopologyImtMssDc where the subsatellite_distance was wrongly computed because the conversion from deg to rad was missing in the off-axis angle.

Also, a `sat_utils` for correct sub-satellite distance computation from off-nadir was added. This one considers the curvature of the Earth (perfect sphere) because for a sparse constellation, an off-nadir angle higher than 47 degrees is expected.

The figure below shows the absolute error from flat vs arc:

<img width="760" height="452" alt="image" src="https://github.com/user-attachments/assets/d57491ba-e7f0-453e-b187-da372e684191" />
