### PR TITLE
fix(utils): Fixed a potential overflow on ecef2lla

### DIFF
--- a/sharc/satellite/utils/sat_utils.py
+++ b/sharc/satellite/utils/sat_utils.py
@@ -19,9 +19,11 @@ def ecef2lla(x: np.ndarray, y: np.ndarray, z: np.ndarray) -> tuple:
     tuple (lat, long, alt)
         lat long and altitude in spherical earth model
     """
-    x = np.atleast_1d(x)
-    y = np.atleast_1d(y)
-    z = np.atleast_1d(z)
+    # Transform to kilometers to prevent overflow
+    x = np.atleast_1d(x).astype(float)
+    y = np.atleast_1d(y).astype(float)
+    z = np.atleast_1d(z).astype(float)
+
     xy = np.sqrt(x**2 + y**2)
 
     lon = np.arccos(x / xy)


### PR DESCRIPTION
Fixed an overflow on ecef2lla when x, y, or z are too big.
That overflow occurred because `x**2` was somehow stored in an int32.
Very odd.
Casting arrays x, y, and z explicitly to float to prevent this.
Environment:
Python version 3.12.7
Windows 10

